### PR TITLE
Translate mocking.md (v5.5)

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -12,14 +12,14 @@
 <a name="introduction"></a>
 ## 介紹
 
-測試 Laravel 應用程式時，你可能希望「模擬」應用程式的某些功能，而不會在特定的測試中實際執行它們。例如，測試控制器的觸發事件，你可能希望模擬物事件監聽器，而不是真的在測試中執行它們。這可以讓你只測試控制器的 HTTP 回應，而不用擔憂事件監聽器的執行，因為事件監聽器能在自己的測試案例中被測試。
+當你測試 Laravel 應用程式時，你可能希望「mock」應用程式的某些功能，而不是在特定的測試中實際執行它們。例如，測試控制器的觸發事件，你可能希望 mock 事件監聽器，而不是真的在測試中執行它們。這可以讓你只測試控制器的 HTTP 回應，而不用擔憂事件監聽器的執行，因為事件監聽器能在自己的測試案例中被測試。
 
-Laravel 為模擬事件、任務和 facade 提供可立即使用的輔助函式。這些輔助函式主要提供方便的 Mockery 層，所以你不用手動寫些複雜的 Mockery 方法呼叫。當然，你可以自由使用 [Mockery](http://docs.mockery.io/en/latest/) 或 PHPUnit 來建立自己的 Mockery。
+Laravel 為 mock 事件、任務和 facade 提供可立即使用的輔助函式。這些輔助函式主要提供方便的 Mockery 層，所以你不用手動寫些複雜的 Mockery 方法呼叫。當然，你可以自由使用 [Mockery](http://docs.mockery.io/en/latest/) 或 PHPUnit 來建立自己的 Mockery。
 
 <a name="bus-fake"></a>
 ## 假 Bus
 
-你可以使用 `Bus` facade 的 `fake` 方法作為 Mockery 的其中一個選擇，並用來預防任務真的被觸發。使用 `fake` 時，會等到測試的程式碼被執行後進行斷言：
+你可以使用 `Bus` facade 的 `fake` 方法作為 Mockery 的其中一個選擇，並用來防止任務被觸發。當使用 `fake` 時，會等到測試的程式碼被執行後進行斷言：
 
     <?php
 
@@ -43,7 +43,7 @@ Laravel 為模擬事件、任務和 facade 提供可立即使用的輔助函式�
                 return $job->order->id === $order->id;
             });
 
-            // 斷言任務是否沒被觸發...
+            // 斷言任務沒有被觸發...
             Bus::assertNotDispatched(AnotherJob::class);
         }
     }
@@ -86,7 +86,7 @@ Laravel 為模擬事件、任務和 facade 提供可立即使用的輔助函式�
 <a name="mail-fake"></a>
 ## 假郵件
 
-你可以使用 `Mail` facade 的 `fake` 方法來預防郵件真的被寄出。你可以斷言 [mailables](/docs/{{version}}/mail) 有沒有寄給使用者，甚至是檢查它們接收的資料。使用 `fake` 時，會等到測試的程式碼被執行後進行斷言：
+你可以使用 `Mail` facade 的 `fake` 方法來防止郵件被寄出。你可以斷言 [mailables](/docs/{{version}}/mail) 有沒有寄給使用者，甚至是檢查它們接收的資料。使用 `fake` 時，會等到測試的程式碼被執行後進行斷言：
 
     <?php
 
@@ -117,10 +117,10 @@ Laravel 為模擬事件、任務和 facade 提供可立即使用的輔助函式�
                        $mail->hasBcc('...');
             });
 
-            // 斷言 mailable 是否寄了兩次...
+            // 斷言 mailable 寄出了兩次...
             Mail::assertSent(OrderShipped::class, 2);
 
-            // 斷言 mailable 是否沒寄出...
+            // 斷言 mailable 沒有寄出...
             Mail::assertNotSent(AnotherMailable::class);
         }
     }
@@ -161,12 +161,12 @@ Laravel 為模擬事件、任務和 facade 提供可立即使用的輔助函式�
                 }
             );
 
-            // 斷言通知是否發送給特定使用者...
+            // 斷言通知發送給特定使用者...
             Notification::assertSentTo(
                 [$user], OrderShipped::class
             );
 
-            // 斷言通知是否沒送出...
+            // 斷言通知沒有送出...
             Notification::assertNotSentTo(
                 [$user], AnotherNotification::class
             );
@@ -200,13 +200,13 @@ Laravel 為模擬事件、任務和 facade 提供可立即使用的輔助函式�
                 return $job->order->id === $order->id;
             });
 
-            // 斷言任務是否被推送到特定隊列...
+            // 斷言任務被推送到特定隊列...
             Queue::assertPushedOn('queue-name', ShipOrder::class);
 
-            // 斷言任務是否被推送兩次...
+            // 斷言任務被推送兩次...
             Queue::assertPushed(ShipOrder::class, 2);
 
-            // 斷言任務是否沒被退送...
+            // 斷言任務沒有被推送...
             Queue::assertNotPushed(AnotherJob::class);
         }
     }
@@ -236,10 +236,10 @@ Laravel 為模擬事件、任務和 facade 提供可立即使用的輔助函式�
                 'avatar' => UploadedFile::fake()->image('avatar.jpg')
             ]);
 
-            // 斷言檔案使否被儲存...
+            // 斷言檔案被儲存...
             Storage::disk('avatars')->assertExists('avatar.jpg');
 
-            // 斷言檔案是否存在...
+            // 斷言檔案不存在...
             Storage::disk('avatars')->assertMissing('missing.jpg');
         }
     }
@@ -249,7 +249,7 @@ Laravel 為模擬事件、任務和 facade 提供可立即使用的輔助函式�
 <a name="mocking-facades"></a>
 ## Facades
 
-Facade 不像是傳統靜態方法的呼叫方式，[Facade](/docs/{{version}}/facades) 是可以被模擬的。這為傳統靜態方法提供一個很大的優點，並為你提供與使用依賴注入一樣的可測試性。你可能經常想模擬在控制器中呼叫 Laravel facade。例如，請參考以下控制器的操作：
+不像傳統靜態方法的呼叫方式，Facade 可以被 mock 的。這相較傳統的靜態方法提供了一個很大的優點，如果你使用依賴注入，則可以為你提供相同的可測試性。當在進行測試時，你可能經常想模擬在控制器中呼叫 Laravel facade。例如，考慮以下控制器的操作：
 
     <?php
 
@@ -272,7 +272,7 @@ Facade 不像是傳統靜態方法的呼叫方式，[Facade](/docs/{{version}}/f
         }
     }
 
-我們能使用 `shouldReceive` 來模擬呼叫 `Cache` facade，這會回傳 [Mockery](https://github.com/padraic/mockery) 模擬實例。因為 facades 實際上是被 Laravel [服務容器](/docs/{{version}}/container)所管理與解析，它們比典型的靜態類別更具可測試性。例如，讓我們模擬呼叫 `Cache` facade 的 `get` 方法：
+我們可以使用 `shouldReceive` 來 mock 呼叫 `Cache` facade，這會回傳 [Mockery](https://github.com/padraic/mockery) mock 實例。因為 facades 實際上是被 Laravel [服務容器](/docs/{{version}}/container)所管理與解析，它們比典型的靜態類別更具可測試性。例如，讓我們模擬呼叫 `Cache` facade 的 `get` 方法：
 
     <?php
 
@@ -298,4 +298,4 @@ Facade 不像是傳統靜態方法的呼叫方式，[Facade](/docs/{{version}}/f
         }
     }
 
-> {note} 你不應該模擬 `Request` facade。而是傳入你想要的輸入到 HTTP 輔助函式方法，像是在執行測試時的 `get` 和 `post`。同樣地，不要模擬 `Config` facade，只要在你的測試中呼叫 `Config::set` 方法。
+> {note} 你不應該 mock `Request` facade。而是在你在執行測試時，請改用 `get` 和 `post` 或其他可用的 HTTP 輔助函式方法來傳入你想要的資料。也請你別 mock `Config` facade，而是直接在你的測試中呼叫 `Config::set` 方法。

--- a/mocking.md
+++ b/mocking.md
@@ -1,25 +1,25 @@
 # Mocking
 
-- [Introduction](#introduction)
-- [Bus Fake](#bus-fake)
-- [Event Fake](#event-fake)
-- [Mail Fake](#mail-fake)
-- [Notification Fake](#notification-fake)
-- [Queue Fake](#queue-fake)
-- [Storage Fake](#storage-fake)
+- [介紹](#introduction)
+- [假 Bus](#bus-fake)
+- [假事件](#event-fake)
+- [假郵件](#mail-fake)
+- [假通知](#notification-fake)
+- [假隊列](#queue-fake)
+- [假儲存](#storage-fake)
 - [Facades](#mocking-facades)
 
 <a name="introduction"></a>
-## Introduction
+## 介紹
 
-When testing Laravel applications, you may wish to "mock" certain aspects of your application so they are not actually executed during a given test. For example, when testing a controller that dispatches an event, you may wish to mock the event listeners so they are not actually executed during the test. This allows you to only test the controller's HTTP response without worrying about the execution of the event listeners, since the event listeners can be tested in their own test case.
+測試 Laravel 應用程式時，你可能希望「模擬」應用程式的某些功能，而不會在特定的測試中實際執行它們。例如，測試控制器的觸發事件，你可能希望模擬物事件監聽器，而不是真的在測試中執行它們。這可以讓你只測試控制器的 HTTP 回應，而不用擔憂事件監聽器的執行，因為事件監聽器能在自己的測試案例中被測試。
 
-Laravel provides helpers for mocking events, jobs, and facades out of the box. These helpers primarily provide a convenience layer over Mockery so you do not have to manually make complicated Mockery method calls. Of course, you are free to use [Mockery](http://docs.mockery.io/en/latest/) or PHPUnit to create your own mocks or spies.
+Laravel 為模擬事件、任務和 facade 提供可立即使用的輔助函式。這些輔助函式主要提供方便的 Mockery 層，所以你不用手動寫些複雜的 Mockery 方法呼叫。當然，你可以自由使用 [Mockery](http://docs.mockery.io/en/latest/) 或 PHPUnit 來建立自己的 Mockery。
 
 <a name="bus-fake"></a>
-## Bus Fake
+## 假 Bus
 
-As an alternative to mocking, you may use the `Bus` facade's `fake` method to prevent jobs from being dispatched. When using fakes, assertions are made after the code under test is executed:
+你可以使用 `Bus` facade 的 `fake` 方法作為 Mockery 的其中一個選擇，並用來預防任務真的被觸發。使用 `fake` 時，會等到測試的程式碼被執行後進行斷言：
 
     <?php
 
@@ -37,21 +37,21 @@ As an alternative to mocking, you may use the `Bus` facade's `fake` method to pr
         {
             Bus::fake();
 
-            // Perform order shipping...
+            // 執行訂單出貨...
 
             Bus::assertDispatched(ShipOrder::class, function ($job) use ($order) {
                 return $job->order->id === $order->id;
             });
 
-            // Assert a job was not dispatched...
+            // 斷言任務是否沒被觸發...
             Bus::assertNotDispatched(AnotherJob::class);
         }
     }
 
 <a name="event-fake"></a>
-## Event Fake
+## 假事件
 
-As an alternative to mocking, you may use the `Event` facade's `fake` method to prevent all event listeners from executing. You may then assert that events were dispatched and even inspect the data they received. When using fakes, assertions are made after the code under test is executed:
+你可以使用 `Event` facade 的 `fake` 方法作為 Mockery 的其中一個選擇，並用來防止所有事件監聽器被觸發。你可以斷言事件有沒有被觸發，甚至是檢查它們接收的資料。使用 `fake` 時，會等到測試的程式碼被執行後進行斷言：
 
     <?php
 
@@ -73,7 +73,7 @@ As an alternative to mocking, you may use the `Event` facade's `fake` method to 
         {
             Event::fake();
 
-            // Perform order shipping...
+            // 執行訂單出貨...
 
             Event::assertDispatched(OrderShipped::class, function ($e) use ($order) {
                 return $e->order->id === $order->id;
@@ -84,9 +84,9 @@ As an alternative to mocking, you may use the `Event` facade's `fake` method to 
     }
 
 <a name="mail-fake"></a>
-## Mail Fake
+## 假郵件
 
-You may use the `Mail` facade's `fake` method to prevent mail from being sent. You may then assert that [mailables](/docs/{{version}}/mail) were sent to users and even inspect the data they received. When using fakes, assertions are made after the code under test is executed:
+你可以使用 `Mail` facade 的 `fake` 方法來預防郵件真的被寄出。你可以斷言 [mailables](/docs/{{version}}/mail) 有沒有寄給使用者，甚至是檢查它們接收的資料。使用 `fake` 時，會等到測試的程式碼被執行後進行斷言：
 
     <?php
 
@@ -104,7 +104,7 @@ You may use the `Mail` facade's `fake` method to prevent mail from being sent. Y
         {
             Mail::fake();
 
-            // Perform order shipping...
+            // 執行訂單出貨...
 
             Mail::assertSent(OrderShipped::class, function ($mail) use ($order) {
                 return $mail->order->id === $order->id;
@@ -117,23 +117,23 @@ You may use the `Mail` facade's `fake` method to prevent mail from being sent. Y
                        $mail->hasBcc('...');
             });
 
-            // Assert a mailable was sent twice...
+            // 斷言 mailable 是否寄了兩次...
             Mail::assertSent(OrderShipped::class, 2);
 
-            // Assert a mailable was not sent...
+            // 斷言 mailable 是否沒寄出...
             Mail::assertNotSent(AnotherMailable::class);
         }
     }
 
-If you are queueing mailables for delivery in the background, you should use the `assertQueued` method instead of `assertSent`:
+如果你在背景執行隊列 mailables 的發送。你應該使用 `assertQueued` 方法，而不是 `assertSent`：
 
     Mail::assertQueued(...);
     Mail::assertNotQueued(...);
 
 <a name="notification-fake"></a>
-## Notification Fake
+## 假通知
 
-You may use the `Notification` facade's `fake` method to prevent notifications from being sent. You may then assert that [notifications](/docs/{{version}}/notifications) were sent to users and even inspect the data they received. When using fakes, assertions are made after the code under test is executed:
+你可以使用 `Notification` facade 的 `fake` 方法來防止通知真的被送出。你可以斷言[通知](/docs/{{version}}/notifications) 是不是發送給使用者，甚至是檢查它們接收的資料。使用 `fake` 時，會等到測試的程式碼被執行後進行斷言：
 
     <?php
 
@@ -151,7 +151,7 @@ You may use the `Notification` facade's `fake` method to prevent notifications f
         {
             Notification::fake();
 
-            // Perform order shipping...
+            // 執行訂單出貨...
 
             Notification::assertSentTo(
                 $user,
@@ -161,12 +161,12 @@ You may use the `Notification` facade's `fake` method to prevent notifications f
                 }
             );
 
-            // Assert a notification was sent to the given users...
+            // 斷言通知是否發送給特定使用者...
             Notification::assertSentTo(
                 [$user], OrderShipped::class
             );
 
-            // Assert a notification was not sent...
+            // 斷言通知是否沒送出...
             Notification::assertNotSentTo(
                 [$user], AnotherNotification::class
             );
@@ -174,9 +174,9 @@ You may use the `Notification` facade's `fake` method to prevent notifications f
     }
 
 <a name="queue-fake"></a>
-## Queue Fake
+## 假隊列
 
-As an alternative to mocking, you may use the `Queue` facade's `fake` method to prevent jobs from being queued. You may then assert that jobs were pushed to the queue and even inspect the data they received. When using fakes, assertions are made after the code under test is executed:
+你可以使用 `Queue` facade 的 `fake` 方法作為 Mockery 的其中一個選擇，並用來防止任務真的被隊列。你可以斷言任務是否被推送到隊列，甚至是檢查它們接收的資料。使用 `fake` 時，會等到測試的程式碼被執行後進行斷言：
 
     <?php
 
@@ -194,27 +194,27 @@ As an alternative to mocking, you may use the `Queue` facade's `fake` method to 
         {
             Queue::fake();
 
-            // Perform order shipping...
+            // 執行訂單出貨...
 
             Queue::assertPushed(ShipOrder::class, function ($job) use ($order) {
                 return $job->order->id === $order->id;
             });
 
-            // Assert a job was pushed to a given queue...
+            // 斷言任務是否被推送到特定隊列...
             Queue::assertPushedOn('queue-name', ShipOrder::class);
 
-            // Assert a job was pushed twice...
+            // 斷言任務是否被推送兩次...
             Queue::assertPushed(ShipOrder::class, 2);
 
-            // Assert a job was not pushed...
+            // 斷言任務是否沒被退送...
             Queue::assertNotPushed(AnotherJob::class);
         }
     }
 
 <a name="storage-fake"></a>
-## Storage Fake
+## 假儲存
 
-The `Storage` facade's `fake` method allows you to easily generate a fake disk that, combined with the file generation utilities of the `UploadedFile` class, greatly simplifies the testing of file uploads. For example:
+`Storage` facade 的 `fake` 方法可以讓你輕易的產生假硬碟，並搭配 `UploadedFile` 類別的檔案產生工具，這可以大大簡化檔案上傳的測試。例如：
 
     <?php
 
@@ -236,20 +236,20 @@ The `Storage` facade's `fake` method allows you to easily generate a fake disk t
                 'avatar' => UploadedFile::fake()->image('avatar.jpg')
             ]);
 
-            // Assert the file was stored...
+            // 斷言檔案使否被儲存...
             Storage::disk('avatars')->assertExists('avatar.jpg');
 
-            // Assert a file does not exist...
+            // 斷言檔案是否存在...
             Storage::disk('avatars')->assertMissing('missing.jpg');
         }
     }
 
-> {tip} By default, the `fake` method will delete all files in its temporary directory. If you would like to keep these files, you may use the "persistentFake" method instead.
+> {tip} 預設的 `fake` 方法會刪除在暫存目錄中的所有檔案。如果你希望保留這些檔案，你可以使用 `persistentFake` 方法來取代。
 
 <a name="mocking-facades"></a>
 ## Facades
 
-Unlike traditional static method calls, [facades](/docs/{{version}}/facades) may be mocked. This provides a great advantage over traditional static methods and grants you the same testability you would have if you were using dependency injection. When testing, you may often want to mock a call to a Laravel facade in one of your controllers. For example, consider the following controller action:
+Facade 不像是傳統靜態方法的呼叫方式，[Facade](/docs/{{version}}/facades) 是可以被模擬的。這為傳統靜態方法提供一個很大的優點，並為你提供與使用依賴注入一樣的可測試性。你可能經常想模擬在控制器中呼叫 Laravel facade。例如，請參考以下控制器的操作：
 
     <?php
 
@@ -260,7 +260,7 @@ Unlike traditional static method calls, [facades](/docs/{{version}}/facades) may
     class UserController extends Controller
     {
         /**
-         * Show a list of all users of the application.
+         * 顯示應用程式所有使用者清單。
          *
          * @return Response
          */
@@ -272,7 +272,7 @@ Unlike traditional static method calls, [facades](/docs/{{version}}/facades) may
         }
     }
 
-We can mock the call to the `Cache` facade by using the `shouldReceive` method, which will return an instance of a [Mockery](https://github.com/padraic/mockery) mock. Since facades are actually resolved and managed by the Laravel [service container](/docs/{{version}}/container), they have much more testability than a typical static class. For example, let's mock our call to the `Cache` facade's `get` method:
+我們能使用 `shouldReceive` 來模擬呼叫 `Cache` facade，這會回傳 [Mockery](https://github.com/padraic/mockery) 模擬實例。因為 facades 實際上是被 Laravel [服務容器](/docs/{{version}}/container)所管理與解析，它們比典型的靜態類別更具可測試性。例如，讓我們模擬呼叫 `Cache` facade 的 `get` 方法：
 
     <?php
 
@@ -298,4 +298,4 @@ We can mock the call to the `Cache` facade by using the `shouldReceive` method, 
         }
     }
 
-> {note} You should not mock the `Request` facade. Instead, pass the input you desire into the HTTP helper methods such as `get` and `post` when running your test. Likewise, instead of mocking the `Config` facade, simply call the `Config::set` method in your tests.
+> {note} 你不應該模擬 `Request` facade。而是傳入你想要的輸入到 HTTP 輔助函式方法，像是在執行測試時的 `get` 和 `post`。同樣地，不要模擬 `Config` facade，只要在你的測試中呼叫 `Config::set` 方法。


### PR DESCRIPTION
## **Translate `mocking.md` (v5.5)**

1. bus fake 不知道怎麼翻
2. mockery 如果是名詞的話保留原文，動詞的話翻譯為模擬
3. 有些句子真的翻得很糟，就麻煩在修改了(像是252和301行)