### PR TITLE
Translate migrations.md (v5.5)

### DIFF
--- a/migrations.md
+++ b/migrations.md
@@ -28,11 +28,11 @@ Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的
 <a name="generating-migrations"></a>
 ## 產生遷移
 
-使用 [Artisan 指令](/docs/{{version}}/artisan) 的 `make:migration` 來建立遷移：
+使用 [Artisan](/docs/{{version}}/artisan) 的 `make:migration` 指令來建立遷移：
 
     php artisan make:migration create_users_table
 
-新遷移會放置於 `database/migrations` 目錄中。每個遷移的檔名會包含時間戳，可以 Laravel 確定遷移的順序。
+新遷移會放置於 `database/migrations` 目錄中。每個遷移的檔名會包含時間戳，可以讓 Laravel 確定遷移的順序。
 
 `--table` 和 `--create` 選項也可以被用於指定資料表名稱和是否依遷移內容建立新資料表。這些選項只在剛產生遷移時填入指定的資料表：
 
@@ -45,7 +45,7 @@ Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的
 <a name="migration-structure"></a>
 ## 遷移結構
 
-遷移類別會有兩個方法：`up` 和 `down`。 `up` 方法被用於新增新資料表，欄位，或索引到你的資料庫，而 `down` 方法則會回朔 `up` 的執行操作。
+遷移類別會有兩個方法：`up` 和 `down`。`up` 方法被用於新增新資料表、欄位、或索引到你的資料庫，而 `down` 方法則會回朔 `up` 的執行操作。
 
 你可以在這兩種方法中使用 Laravel schema 建構器來建立和修改的資料表。想學習 `Schema` 建構器可用的所有方法，[請查看該文件](#creating-tables)。例如，這個遷移範例會建立 `flights` 資料表：
 
@@ -94,18 +94,18 @@ Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的
 
 #### 在正式上線環境強制執行遷移
 
-有些遷移操作是不可逆的，也就意味著這些操作可能會導致你遺失資料。為了預防你在正式上線的資料庫上執行這些指令，系統會在執行指令前詢問你是否要執行該指令。想不用被提示的情況下強制執行指令，可使用 `--force` 選項：
+有些遷移操作是不可逆的，也就意味著這些操作可能會導致你遺失資料。為了防止你在正式上線的資料庫上執行這些指令，系統會在執行指令前詢問你是否要執行該指令。要強制命令在沒有提示的情況下執行，可以使用 `--force` 選項：
 
     php artisan migrate --force
 
 <a name="rolling-back-migrations"></a>
 ### 還原遷移
 
-你可以使用 `rollback` 指令來還原最後的遷移操作。這個指令還原最後批次的遷移，這可能包含多個遷移檔案：
+你可以使用 `rollback` 指令來還原最後的遷移操作。這個指令還原最後「批次」的遷移，這可能包含多個遷移檔案：
 
     php artisan migrate:rollback
 
-你可以提供在 `rollback` 指令加上 `step` 選項來還原限定次數的遷移。例如，以下的指令會還原最後五次遷移：
+你可以在 `rollback` 指令提供 `step` 選項來限制遷移的次數。例如，以下的指令會還原最後五次遷移：
 
     php artisan migrate:rollback --step=5
 
@@ -119,10 +119,10 @@ Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的
 
     php artisan migrate:refresh
 
-    // 覆寫資料庫並執行資料庫填充...
+    // 刷新資料庫並執行資料庫填充...
     php artisan migrate:refresh --seed
 
-你可以在 `refresh` 中提供 `step` 選項來指定次數的還原與重新遷移。例如，以下指令會還原與重新遷移最後五次的遷移：
+你可以在 `refresh` 中提供 `step` 選項來限制還原和重新遷移的次數。例如，以下指令會還原和重新遷移最後五次的遷移：
 
     php artisan migrate:refresh --step=5
 
@@ -140,17 +140,17 @@ Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的
 <a name="creating-tables"></a>
 ### 建立資料表
 
-在 `Schema` facade 上使用 `create` 方法來建立新的資料表。`create` 方法可接受兩個參數：其一是資料表名稱，其二是`閉包`。閉包可接收被用於定義新資料表的 `Blueprint` 物件：
+要建立一個新的資料表，可以使用 `Schema` facade 的 `create` `方法。create` 方法可接受兩個參數。第一個是資料表的名稱，第二個是 `Closure`，它接收一個可用於定義新資料表的 `Blueprint` 物件：
 
     Schema::create('users', function (Blueprint $table) {
         $table->increments('id');
     });
 
-當然，你可以在建立資料表的時候，使用任何 schema 建構器的[欄位方法](#creating-columns)來定義資料表的欄位。
+當然，當你建立資料表時，你可以使用 schema 建構器任何的[欄位方法](#creating-columns)來定義資料表的欄位。
 
 #### 檢查資料表與欄位是否存在
 
-你可以使用 `hasTable` 和 `hasColumn` 方法來輕易地檢查資料表或欄位是否存在：
+你可以輕鬆的使用 `hasTable` 和 `hasColumn` 方法來檢查資料表或欄位是否存在：
 
     if (Schema::hasTable('users')) {
         //
@@ -160,21 +160,22 @@ Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的
         //
     }
 
-#### 連線與儲存的引擎
+#### 連線與資料表選項
 
-如果你想對非預設的資料庫連線執行 schema 操作，可使用 `connection` 方法：
+如果你想要在資料庫連線上執行一個非預設的 schema 操作，你可以使用 `connection` 方法：
 
     Schema::connection('foo')->create('users', function (Blueprint $table) {
         $table->increments('id');
     });
 
-你可以在 schema 建構器上使用 `engine` 屬性來定義資料表的儲存引擎：
+你可以在 Schema 建構器上使用以下指令來定義資料表的選項：
 
-    Schema::create('users', function (Blueprint $table) {
-        $table->engine = 'InnoDB';
-
-        $table->increments('id');
-    });
+指令  |  描述
+-------  |  -----------
+`$table->engine = 'InnoDB';`  |  指令資料表儲存引擎（僅限 MySQL）。
+`$table->charset = 'utf8';`  |  指定資料表的預設字元編碼（僅限 MySQL）。
+`$table->collation = 'utf8_unicode_ci';`  |  指定資料表的預設排序規則（僅限 MySQL）。
+`$table->temporary();`  |  建立一個臨時資料表（SQL Server 除外）。
 
 <a name="renaming-and-dropping-tables"></a>
 ### 重新命名與移除資料表
@@ -191,7 +192,7 @@ Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的
 
 #### 重新命名已有外鍵的資料表
 
-在重新命名資料表前，你應該驗證在資料表上的任何外鍵約束在遷移檔案中都有明確的名稱，而不是讓 Laravel 發給你的基本約束名稱。否則外鍵約束名稱會沿用舊資料表。
+在重新命名資料表前，你應該驗證在資料表上的任何外鍵約束在遷移檔案中都有明確的名稱，而不是由 Laravel 分配一個基於約束的名稱。否則外鍵約束名稱會沿用舊資料表。
 
 <a name="columns"></a>
 ## 欄位
@@ -199,7 +200,7 @@ Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的
 <a name="creating-columns"></a>
 ### 建立欄位
 
-在 `Schema` facade 上的 `table` 方法可被用於更新已存在的資料表。像是 `create` 方法、`table` 方法可接受兩個參數：資料表名稱和`閉包`，然後閉包可接受一個 `Blueprint` 實例，可用於新增欄位到資料表：
+在 `Schema` facade 上的 `table` 方法可被用於更新已存在的資料表。像是 `create` 方法、`table` 方法可接受兩個參數：第一個是資料表的名稱，第二個是 `Closure`，它接收一個可用於定義新資料表的 `Blueprint` 物件：
 
     Schema::table('users', function (Blueprint $table) {
         $table->string('email');
@@ -207,22 +208,22 @@ Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的
 
 #### 可用的欄位型別
 
-當然，schema 建構器包含各種欄位類型，你可以在建構資料表的時候指定這些方法：
+當然，schema 建構器包含各種欄位的類型，當你在建立資料表時可以指定這些方法：
 
-指令  | 說明
+指令  | 描述
 ------------- | -------------
-`$table->bigIncrements('id');`  |  自動遞增相當於 UNSIGNED BIGINT（主鍵）欄位。
+`$table->bigIncrements('id');`  |  使用「UNSIGNED BIG INTEGER」相當於自動遞增 ID（主鍵）。
 `$table->bigInteger('votes');`  |  相當於 BIGINT 欄位。
 `$table->binary('data');`  |  相當於 BLOB 欄位。
 `$table->boolean('confirmed');`  |  相當於 BOOLEAN 欄位
-`$table->char('name', 100);`  |  相當於 CHAR 欄位並可選擇長度。
+`$table->char('name', 100);`  |  相當於 CHAR 欄位並可指定長度。
 `$table->date('created_at');`  |  相當於 DATE 欄位。
-`$table->dateTime('created_at');`  |  相當於 DATETIME 對等欄位。
+`$table->dateTime('created_at');`  |  相當於 DATETIME 欄位。
 `$table->dateTimeTz('created_at');`  |  相當於 DATETIME （含時區） 欄位。
-`$table->decimal('amount', 8, 2);`  |  相當於 DECIMAL 欄位，並帶有精度（整數位長度）與基數（小數點長度）。
-`$table->double('amount', 8, 2);`  |  相當於 DOUBLE 欄位，並帶有精度（整數位長度）與基數（小數點長度）。
+`$table->decimal('amount', 8, 2);`  |  相當於 DECIMAL 欄位，並帶有精度（整數位長度）與奇數（小數點長度）。
+`$table->double('amount', 8, 2);`  |  相當於 DOUBLE 欄位，並帶有精度（整數位長度）與奇數（小數點長度）。
 `$table->enum('level', ['easy', 'hard']);`  |  相當於 ENUM 欄位。
-`$table->float('amount', 8, 2);`  |  相當於 FLOAT 欄位，並帶有精度（整數位長度）與基數（小數點長度）。
+`$table->float('amount', 8, 2);`  |  相當於 FLOAT 欄位，並帶有精度（整數位長度）與奇數（小數點長度）。
 `$table->geometry('positions');`  |  相當於 GEOMETRY 欄位。
 `$table->geometryCollection('positions');`  |  相當於 GEOMETRYCOLLECTION 欄位。
 `$table->increments('id');`  |  自動遞增相當於 UNSIGNED INTEGER（主鍵）欄位。
@@ -233,34 +234,34 @@ Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的
 `$table->lineString('positions');`  |  相當於 LINESTRING 欄位。
 `$table->longText('description');`  |  相當於 LONGTEXT 欄位。
 `$table->macAddress('device');`  |  相當於 MAC 位址欄位。
-`$table->mediumIncrements('id');`  |  自動遞增相當於 UNSIGNED MEDIUMINT（主鍵）欄位。
+`$table->mediumIncrements('id');`  |  使用「UNSIGNED BIG INTEGER」相當於自動遞增 ID（主鍵）。
 `$table->mediumInteger('votes');`  |  相當於 MEDIUMINT 欄位。
 `$table->mediumText('description');`  |  相當於 MEDIUMTEXT 欄位。
-`$table->morphs('taggable');`  |  新增相當於 `taggable_id` 的 UNSIGNED INTEGER 和 `taggable_type` 的 VARCHAR 欄位。
+`$table->morphs('taggable');`  |  加入無符號的 INTEGER `taggable_id` 和 STRING `taggable_type。`
 `$table->multiLineString('positions');`  |  相當於 MULTILINESTRING 欄位。
 `$table->multiPoint('positions');`  |  相當於 MULTIPOINT 欄位。
 `$table->multiPolygon('positions');`  |  相當於 MULTIPOLYGON 欄位。
-`$table->nullableMorphs('taggable');`  |  新增可以 null 的 `morphs()` 欄位版本。
-`$table->nullableTimestamps();`  |  新增可以 null 的 `timestamps()` 欄位版本。
+`$table->nullableMorphs('taggable');`  |  Nullable 版本的 `morphs()` 欄位。
+`$table->nullableTimestamps();`  |  `timestamps()` 方法的別名。
 `$table->point('position');`  |  相當於 POINT 欄位。
 `$table->polygon('positions');`  |  相當於 POLYGON 欄位。
-`$table->rememberToken();`  |  相當於新增可以 null 的 `remember_token` VARCHAR(100) 欄位。
-`$table->smallIncrements('id');`  |  自動遞增相當於 UNSIGNED SMALLINT（主鍵）欄位。
+`$table->rememberToken();`  |  相當於新增 nullable 的 `remember_token` VARCHAR(100) 欄位。
+`$table->smallIncrements('id');`  |  使用「UNSIGNED SMALL INTEGER」相當於自動遞增 ID（主鍵）。
 `$table->smallInteger('votes');`  |  相當於 SMALLINT 欄位。
-`$table->softDeletes();`  |  相當於為緩刪除新增可以 null 的 `deleted_at` 時間戳欄位。
-`$table->softDeletesTz();`  |  相當於為緩刪除新增可以 null 的 `deleted_at` 時間戳（含時區）欄位。
-`$table->string('name', 100);`  |  相當於 VARCHAR 欄位並可選擇長度。
+`$table->softDeletes();`  |  相當於為軟刪除新增 nullable 的 `deleted_at` 時間戳欄位。
+`$table->softDeletesTz();`  |  相當於為軟刪除新增 nullable 的 `deleted_at` 時間戳（含時區）欄位。
+`$table->string('name', 100);`  |  相當於 VARCHAR 欄位並可指定長度。
 `$table->text('description');`  |  相當於 TEXT 欄位。
 `$table->time('sunrise');`  |  相當於 TIME 欄位。
 `$table->timeTz('sunrise');`  |  相當於 TIME（含時區）欄位。
 `$table->timestamp('added_on');`  |  相當於 TIMESTAMP 欄位。
 `$table->timestampTz('added_on');`  |  相當於 TIMESTAMP（含時區）欄位。
-`$table->timestamps();`  |  相當於新增可以 null 的 `created_at` 和 `updated_at` 時間戳欄位。
-`$table->timestampsTz();`  |  相當於新增可以 null 的 `created_at` 和 `updated_at` 時間戳（含時區）欄位。
+`$table->timestamps();`  |  相當於新增 nullable 的 `created_at` 和 `updated_at` 時間戳欄位。
+`$table->timestampsTz();`  |  相當於新增 nullable 的 `created_at` 和 `updated_at` 時間戳（含時區）欄位。
 `$table->tinyIncrements('id');`  |  自動遞增相當於 UNSIGNED TINYINT（主鍵）欄位。
 `$table->tinyInteger('votes');`  |  相當於 TINYINT 欄位欄位。
 `$table->unsignedBigInteger('votes');`  |  相當於 UNSIGNED BIGINT 欄位。
-`$table->unsignedDecimal('amount', 8, 2);`  |  相當於 UNSIGNED DECIMAL 欄位，並帶有精度（整數位長度）與基數（小數點長度）。
+`$table->unsignedDecimal('amount', 8, 2);`  |  相當於 UNSIGNED DECIMAL 欄位，並帶有精度（整數位長度）與奇數（小數點長度）。
 `$table->unsignedInteger('votes');`  |  相當於 UNSIGNED INTEGER 欄位。
 `$table->unsignedMediumInteger('votes');`  |  相當於 UNSIGNED MEDIUMINT 欄位。
 `$table->unsignedSmallInteger('votes');`  |  相當於 UNSIGNED SMALLINT 欄位。
@@ -270,35 +271,35 @@ Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的
 <a name="column-modifiers"></a>
 ### 欄位修飾
 
-除了以上的欄位類型清單，這有幾個欄位「修飾」可以用於新增欄位到資料表。例如，你可以使用 `nullable` 方法來使欄位「nullable」：
+除了上面列出的欄位類型之外，這有還有一些欄位「修飾」可用於新增欄位到資料表。例如，你可以使用 `nullable` 方法來使欄位為「nullable」：
 
     Schema::table('users', function (Blueprint $table) {
         $table->string('email')->nullable();
     });
 
-以下是所有可用的欄位修飾清單，這個清單不含 [索引修飾](#creating-indexes)：
+以下是所有可用欄位修飾的列表，這個清單不包含[索引修飾](#creating-indexes)：
 
 修飾方法  | 說明
 ------------- | -------------
-`->after('column')`  |  將該欄位放置其他欄位「之後」。（MySQL 限定）
+`->after('column')`  |  將該欄位放置其他欄位「之後」。（僅限 MySQL）
 `->autoIncrement()`  |  設定 INTEGER 欄位能自動遞增（主鍵）
-`->charset('utf8')`  |  為欄位指定字元編碼。（MySQL 限定）
-`->collation('utf8_unicode_ci')`  |  為欄位指定序。（MySQL 與 SQL 伺服器限定）
-`->comment('my comment')`  |  為欄位新增註解。 （MySQL 限定）
+`->charset('utf8')`  |  指定欄位編碼。（僅限 MySQL）
+`->collation('utf8_unicode_ci')`  |  指定欄位排序規則（僅限 MySQL 和 SQL Server）
+`->comment('my comment')`  |  為欄位新增註解。 （僅限 MySQL）
 `->default($value)`  |  為欄位指定「預設」值。
-`->first()`  |  將此欄位放置於資料表的「第一個」。（MySQL 限定）
+`->first()`  |  將欄位放置於資料表的「第一欄」。（僅限 MySQL）
 `->nullable($value = true)`  |  讓欄位預設允許寫入 NULL 值。
-`->storedAs($expression)`  |  建立一個儲存產生的欄位。（MySQL 限定）
-`->unsigned()`  |  設定 INTEGER 欄位為 UNSIGNED。 （MySQL 限定）
-`->useCurrent()`  |  設定 TIMESTAMP 欄位要使用 CURRENT_TIMESTAMP 作為預設值。
-`->virtualAs($expression)`  |  建立一個虛擬產生的欄位。（MySQL 限定）
+`->storedAs($expression)`  |  建立一個儲存產生的欄位。（僅限 MySQL）
+`->unsigned()`  |  設定 INTEGER 欄位為 UNSIGNED。 （僅限 MySQL）
+`->useCurrent()`  |  設定 TIMESTAMP 欄位使用 CURRENT_TIMESTAMP 作為預設值。
+`->virtualAs($expression)`  |  建立一個虛擬產生的欄位。（僅限 MySQL）
 
 <a name="modifying-columns"></a>
 ### 修改欄位
 
 #### 必要條件
 
-在修改欄位之前，請務必在你的 `composer.json` 檔案新增 `doctrine/dbal` 依賴。Doctrine DBAL 函式庫被用於判斷當前欄位狀態與建立調整指定欄位的 SQL 查詢：
+在修改欄位之前，請務必在你的 `composer.json` 檔案新增 `doctrine/dbal` 依賴。Doctrine DBAL 函式庫被用於判斷目前欄位狀態，並建立調整指定欄位的 SQL 查詢：
 
     composer require doctrine/dbal
 
@@ -316,11 +317,11 @@ Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的
         $table->string('name', 50)->nullable()->change();
     });
 
-> {note} 以下欄位類型不能被「更改」：char、double、enum、mediumInteger、timestamp、tinyInteger、ipAddress、json、jsonb、macAddress、mediumIncrements、morphs、nullableMorphs、nullableTimestamps、softDeletes、timeTz、timestampTz、timestamps、timestampsTz、unsignedMediumInteger、unsignedTinyInteger、uuid。
+> {note} 只有以下欄位類型能被「更改」：bigInteger、binary、boolean、date、dateTime、dateTimeTz、decimal、integer、json、longText、mediumText、smallInteger、string、text、time、unsignedBigInteger、unsignedInteger 和 unsignedSmallInteger.
 
 #### 重新命名欄位
 
-你可以在 Schema 建構器上使用 `renameColumn` 方法來重新命名欄位。再重新命名欄位之前，請務必在你的 `composer.json` 檔案上新增 `doctrine/dbal` 依賴：
+要重新命名欄位，你可以使用 Schema 建構器的 `renameColumn` 方法。在重新命名欄位之前，請務必在你的 `composer.json` 檔案上加入 `doctrine/dbal` 依賴：
 
     Schema::table('users', function (Blueprint $table) {
         $table->renameColumn('from', 'to');
@@ -331,13 +332,13 @@ Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的
 <a name="dropping-columns"></a>
 ### 移除欄位
 
-你可以在 Schema 建構器上使用 `dropColumn` 方法來移除欄位。從 SQLite 資料庫移除欄位之前，你會需要在你的 `composer.json` 檔案上新增 `doctrine/dbal` 依賴，並在你的終端機執行 `composer update`來安裝該函式庫：
+你可以在 Schema 建構器上使用 `dropColumn` 方法來移除欄位。在 SQLite 資料庫移除欄位之前，你會需要在你的 `composer.json` 檔案上新增 `doctrine/dbal` 依賴，並在你的終端機執行 `composer update`來安裝該函式庫：
 
     Schema::table('users', function (Blueprint $table) {
         $table->dropColumn('votes');
     });
 
-你可以從資料表的上傳入欄位名稱陣列到 `dropColumn` 方法來移除多個欄位：
+你可以透過傳送一組欄位名稱陣列給 `dropColumn` 方法來刪除資料表中多個欄位：
 
     Schema::table('users', function (Blueprint $table) {
         $table->dropColumn(['votes', 'avatar', 'location']);
@@ -345,13 +346,23 @@ Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的
 
 > {note} 當使用 SQLite 資料庫時，並不支援在單一遷移中移除或修改多個欄位。
 
+#### 可用的指令別名
+
+指令  |  描述
+-------  |  -----------
+`$table->dropRememberToken();`  |  刪掉 `remember_token` 欄位。
+`$table->dropSoftDeletes();`  |  刪掉 `deleted_at` 欄位。
+`$table->dropSoftDeletesTz();`  |  `dropSoftDeletes()` 方法的別名。
+`$table->dropTimestamps();`  |  刪掉 `created_at` 和 `updated_at` 欄位。
+`$table->dropTimestampsTz();` |  `dropTimestamps()` 方法的別名。
+
 <a name="indexes"></a>
 ## 索引
 
 <a name="creating-indexes"></a>
 ### 建立索引
 
-schema 建構器支援幾個索引類型。首先，讓我們看一下指定欄位的值必須是 unique 的範例。要建立索引，我們可以只鏈結 `unique` 方法到欄位定義上：
+Schema 建構器支援多種類型的索引。要建立索引，我們可以簡單地將 `unique` 方法鏈結到欄位定義上：
 
     $table->string('email')->unique();
 
@@ -359,11 +370,11 @@ schema 建構器支援幾個索引類型。首先，讓我們看一下指定欄�
 
     $table->unique('email');
 
-你甚至可以將欄位的陣列傳入 `index` 方法來建立複合索引：
+你甚至可以將一組陣列傳給一個 `index` 方法來建立一個複合索引：
 
     $table->index(['account_id', 'created_at']);
 
-Laravel 會自動產生一個合理的索引名稱，但你可以指定你要的名稱作為第二參數，並傳入該方法：
+Laravel 將會自動產生一個合理的索引名稱，但是你可以傳送第二個參數到方法來指定索引的名稱：
 
     $table->unique('email', 'unique_email');
 
@@ -371,20 +382,20 @@ Laravel 會自動產生一個合理的索引名稱，但你可以指定你要的
 
 指令  | 說明
 ------------- | -------------
-`$table->primary('id');`  |  新增主鍵。
+`$table->primary('id');`  |  新增一個主鍵。
 `$table->primary(['id', 'parent_id']);`  |  新增複合鍵。
-`$table->unique('email');`  |  新增唯一的索引。
-`$table->index('state');`  |  新增基本的索引。
-`$table->spatialIndex('location');`  |  新增空間索引。（MySQL 限定）
+`$table->unique('email');`  |  新增一個唯一的索引。
+`$table->index('state');`  |  新增一個基本的索引。
+`$table->spatialIndex('location');`  |  新增一個空間索引（SQLite 除外）
 
-#### 索引長度與 MySQL 與 MariaDB
+#### 索引長度與 MySQL / MariaDB
 
-Laravel 預設使用 `utf8mb4` 字元編碼， 包括支援在資料庫中儲存「表情符號」。如果你執行的 MySQL 版本比 5.5.7 版本還舊，或 MariaDB 還沒升級至 10.2.2 以上，又想要在遷移被產生時 MySQL 能順利的為它們建立索引，你需要手動設定預設字串長度。你可以在 `AppServiceProvider` 中呼叫 `Schema::defaultStringLength` 方法來設定：
+Laravel 預設使用 `utf8mb4` 字元編碼， 包括支援在資料庫中儲存「表情符號」。如果你執行的 MySQL 是早於 5.7.7 版本或者是 MariaDB 是早於 10.2.2 版本的，則可能需要手動設定由遷移產生的預設字串長度，方便 MySQL 為它們建立索引。你可以在 `AppServiceProvider` 中呼叫 `Schema::defaultStringLength` 方法來設定：
 
     use Illuminate\Support\Facades\Schema;
 
     /**
-     * 引導任何應用程式服務。
+     * 啟動任何應用程式服務。
      *
      * @return void
      */
@@ -400,13 +411,14 @@ Laravel 預設使用 `utf8mb4` 字元編碼， 包括支援在資料庫中儲存
 
 要移除索引，你必須指定該索引的名稱。Laravel 預設會自動為索引分配一個合理的名稱。只要將資料表名稱、索引欄位名稱和索引類型連接再一起。這裡有一些範例：
 
-指令  | 說明
+指令  | 描述
 ------------- | -------------
 `$table->dropPrimary('users_id_primary');`  |  從「users」資料表移除主鍵。
 `$table->dropUnique('users_email_unique');`  |  從「users」資料表移除唯一索引。
 `$table->dropIndex('geo_state_index');`  |  從「geo」資料表移除基本的索引。
+`$table->dropSpatialIndex('geo_location_spatialindex');`  |  從「geo」資料表中移除一個空間索引。（SQLite 除外）。
 
-如果你傳入欄位陣列到 `dropIndex` 方法，會根據資料表名稱、欄位和鍵的類型來產生要移除的預設索引名稱：
+如果將一個欄位陣列傳給一個刪除索引的方法，會根據資料表名稱、欄位和鍵的類型來產生要移除的預設索引名稱：
 
     Schema::table('geo', function (Blueprint $table) {
         $table->dropIndex(['state']); // 移除 'geo_state_index' 索引
@@ -423,7 +435,7 @@ Laravel 也為建立外鍵約束提供支援，這是用於在資料庫層面強
         $table->foreign('user_id')->references('id')->on('users');
     });
 
-你也可以指定約束的「on delete」及「on update」作為所需的操作：
+你也可以為約束的「on delete」和「on update」屬性指定所需的操作：
 
     $table->foreign('user_id')
           ->references('id')->on('users')

--- a/migrations.md
+++ b/migrations.md
@@ -1,53 +1,53 @@
-# Database: Migrations
+# 資料庫：遷移
 
-- [Introduction](#introduction)
-- [Generating Migrations](#generating-migrations)
-- [Migration Structure](#migration-structure)
-- [Running Migrations](#running-migrations)
-    - [Rolling Back Migrations](#rolling-back-migrations)
-- [Tables](#tables)
-    - [Creating Tables](#creating-tables)
-    - [Renaming / Dropping Tables](#renaming-and-dropping-tables)
-- [Columns](#columns)
-    - [Creating Columns](#creating-columns)
-    - [Column Modifiers](#column-modifiers)
-    - [Modifying Columns](#modifying-columns)
-    - [Dropping Columns](#dropping-columns)
-- [Indexes](#indexes)
-    - [Creating Indexes](#creating-indexes)
-    - [Dropping Indexes](#dropping-indexes)
-    - [Foreign Key Constraints](#foreign-key-constraints)
+- [介紹](#introduction)
+- [產生遷移](#generating-migrations)
+- [遷移結構](#migration-structure)
+- [執行遷移](#running-migrations)
+    - [還原遷移](#rolling-back-migrations)
+- [資料表](#tables)
+    - [建立資料表](#creating-tables)
+    - [重新命名與移除資料表](#renaming-and-dropping-tables)
+- [欄位](#columns)
+    - [建立欄位](#creating-columns)
+    - [欄位修飾](#column-modifiers)
+    - [修改欄位](#modifying-columns)
+    - [移除欄位](#dropping-columns)
+- [索引](#indexes)
+    - [建立索引](#creating-indexes)
+    - [移除索引](#dropping-indexes)
+    - [外鍵約束](#foreign-key-constraints)
 
 <a name="introduction"></a>
-## Introduction
+## 介紹
 
-Migrations are like version control for your database, allowing your team to easily modify and share the application's database schema. Migrations are typically paired with Laravel's schema builder to easily build your application's database schema. If you have ever had to tell a teammate to manually add a column to their local database schema, you've faced the problem that database migrations solve.
+遷移，可以說是資料庫的版本控制，可以讓你的團隊輕易修改與共享應用程式的資料庫結構。遷移通常會搭配 Laravel 的 schema 建構器來輕易的建構資料庫的結構。如果你曾有過不得不告知團隊要手動新增欄位到各自的本機資料庫結構的情況，那你可以使用資料庫遷移來解決這個問題。
 
-The Laravel `Schema` [facade](/docs/{{version}}/facades) provides database agnostic support for creating and manipulating tables across all of Laravel's supported database systems.
+Laravel `Schema` [facade](/docs/{{version}}/facades) 為所有 Laravel 支援的資料庫系統提供建立和操作資料庫的相容性支援。
 
 <a name="generating-migrations"></a>
-## Generating Migrations
+## 產生遷移
 
-To create a migration, use the `make:migration` [Artisan command](/docs/{{version}}/artisan):
+使用 [Artisan 指令](/docs/{{version}}/artisan) 的 `make:migration` 來建立遷移：
 
     php artisan make:migration create_users_table
 
-The new migration will be placed in your `database/migrations` directory. Each migration file name contains a timestamp which allows Laravel to determine the order of the migrations.
+新遷移會放置於 `database/migrations` 目錄中。每個遷移的檔名會包含時間戳，可以 Laravel 確定遷移的順序。
 
-The `--table` and `--create` options may also be used to indicate the name of the table and whether the migration will be creating a new table. These options simply pre-fill the generated migration stub file with the specified table:
+`--table` 和 `--create` 選項也可以被用於指定資料表名稱和是否依遷移內容建立新資料表。這些選項只在剛產生遷移時填入指定的資料表：
 
     php artisan make:migration create_users_table --create=users
 
     php artisan make:migration add_votes_to_users_table --table=users
 
-If you would like to specify a custom output path for the generated migration, you may use the `--path` option when executing the `make:migration` command. The given path should be relative to your application's base path.
+如果你希望為產生的遷移指定自訂的輸出路徑。你可以在執行時 `make:migration` 指令的時候使用 `--path` 選項。給定的路徑應該要是應用程式基本路徑的相對路徑。
 
 <a name="migration-structure"></a>
-## Migration Structure
+## 遷移結構
 
-A migration class contains two methods: `up` and `down`. The `up` method is used to add new tables, columns, or indexes to your database, while the `down` method should simply reverse the operations performed by the `up` method.
+遷移類別會有兩個方法：`up` 和 `down`。 `up` 方法被用於新增新資料表，欄位，或索引到你的資料庫，而 `down` 方法則會回朔 `up` 的執行操作。
 
-Within both of these methods you may use the Laravel schema builder to expressively create and modify tables. To learn about all of the methods available on the `Schema` builder, [check out its documentation](#creating-tables). For example, this migration example creates a `flights` table:
+你可以在這兩種方法中使用 Laravel schema 建構器來建立和修改的資料表。想學習 `Schema` 建構器可用的所有方法，[請查看該文件](#creating-tables)。例如，這個遷移範例會建立 `flights` 資料表：
 
     <?php
 
@@ -58,7 +58,7 @@ Within both of these methods you may use the Laravel schema builder to expressiv
     class CreateFlightsTable extends Migration
     {
         /**
-         * Run the migrations.
+         * 執行遷移。
          *
          * @return void
          */
@@ -73,7 +73,7 @@ Within both of these methods you may use the Laravel schema builder to expressiv
         }
 
         /**
-         * Reverse the migrations.
+         * 回朔遷移。
          *
          * @return void
          */
@@ -83,67 +83,74 @@ Within both of these methods you may use the Laravel schema builder to expressiv
         }
     }
 
-
 <a name="running-migrations"></a>
-## Running Migrations
+## 執行遷移
 
-To run all of your outstanding migrations, execute the `migrate` Artisan command:
+你可以執行 Artisan 指令的 `migrate` 來執行所有未完成的遷移：
 
     php artisan migrate
 
-> {note} If you are using the [Homestead virtual machine](/docs/{{version}}/homestead), you should run this command from within your virtual machine.
+> {note} 如果你使用 [Homestead 虛擬機](/docs/{{version}}/homestead)，你應該從你的虛擬機中執行這個指令。
 
-#### Forcing Migrations To Run In Production
+#### 在正式上線環境強制執行遷移
 
-Some migration operations are destructive, which means they may cause you to lose data. In order to protect you from running these commands against your production database, you will be prompted for confirmation before the commands are executed. To force the commands to run without a prompt, use the `--force` flag:
+有些遷移操作是不可逆的，也就意味著這些操作可能會導致你遺失資料。為了預防你在正式上線的資料庫上執行這些指令，系統會在執行指令前詢問你是否要執行該指令。想不用被提示的情況下強制執行指令，可使用 `--force` 選項：
 
     php artisan migrate --force
 
 <a name="rolling-back-migrations"></a>
-### Rolling Back Migrations
+### 還原遷移
 
-To rollback the latest migration operation, you may use the `rollback` command. This command rolls back the last "batch" of migrations, which may include multiple migration files:
+你可以使用 `rollback` 指令來還原最後的遷移操作。這個指令還原最後批次的遷移，這可能包含多個遷移檔案：
 
     php artisan migrate:rollback
 
-You may rollback a limited number of migrations by providing the `step` option to the `rollback` command. For example, the following command will rollback the last five migrations:
+你可以提供在 `rollback` 指令加上 `step` 選項來還原限定次數的遷移。例如，以下的指令會還原最後五次遷移：
 
     php artisan migrate:rollback --step=5
 
-The `migrate:reset` command will roll back all of your application's migrations:
+`migrate:reset` 指令會還原所有應用程式的遷移：
 
     php artisan migrate:reset
 
-#### Rollback & Migrate In Single Command
+#### 使用單一指令來還原與遷移
 
-The `migrate:refresh` command will roll back all of your migrations and then execute the `migrate` command. This command effectively re-creates your entire database:
+`migrate:refresh` 指令會還原所有遷移，然後執行 `migrate` 指令。這個指令可有效的重建整個資料庫：
 
     php artisan migrate:refresh
 
-    // Refresh the database and run all database seeds...
+    // 覆寫資料庫並執行資料庫填充...
     php artisan migrate:refresh --seed
 
-You may rollback & re-migrate a limited number of migrations by providing the `step` option to the `refresh` command. For example, the following command will rollback & re-migrate the last five migrations:
+你可以在 `refresh` 中提供 `step` 選項來指定次數的還原與重新遷移。例如，以下指令會還原與重新遷移最後五次的遷移：
 
     php artisan migrate:refresh --step=5
 
+#### 移除所有資料資料表與遷移
+
+`migrate:fresh` 指令會移除資料庫的所有資料表，然後執行 `migrate` 指令：
+
+    php artisan migrate:fresh
+
+    php artisan migrate:fresh --seed
+
 <a name="tables"></a>
-## Tables
+## 資料表
 
 <a name="creating-tables"></a>
-### Creating Tables
+### 建立資料表
 
-To create a new database table, use the `create` method on the `Schema` facade. The `create` method accepts two arguments. The first is the name of the table, while the second is a `Closure` which receives a `Blueprint` object that may be used to define the new table:
+在 `Schema` facade 上使用 `create` 方法來建立新的資料表。`create` 方法可接受兩個參數：其一是資料表名稱，其二是`閉包`。閉包可接收被用於定義新資料表的 `Blueprint` 物件：
 
     Schema::create('users', function (Blueprint $table) {
         $table->increments('id');
     });
 
-Of course, when creating the table, you may use any of the schema builder's [column methods](#creating-columns) to define the table's columns.
+當然，你可以在建立資料表的時候，使用任何 schema 建構器的[欄位方法](#creating-columns)來定義資料表的欄位。
 
-#### Checking For Table / Column Existence
+#### 檢查資料表與欄位是否存在
 
-You may easily check for the existence of a table or column using the `hasTable` and `hasColumn` methods:
+你可以使用 `hasTable` 和 `hasColumn` 方法來輕易地檢查資料表或欄位是否存在：
 
     if (Schema::hasTable('users')) {
         //
@@ -153,15 +160,15 @@ You may easily check for the existence of a table or column using the `hasTable`
         //
     }
 
-#### Connection & Storage Engine
+#### 連線與儲存的引擎
 
-If you want to perform a schema operation on a database connection that is not your default connection, use the `connection` method:
+如果你想對非預設的資料庫連線執行 schema 操作，可使用 `connection` 方法：
 
     Schema::connection('foo')->create('users', function (Blueprint $table) {
         $table->increments('id');
     });
 
-You may use the `engine` property on the schema builder to define the table's storage engine:
+你可以在 schema 建構器上使用 `engine` 屬性來定義資料表的儲存引擎：
 
     Schema::create('users', function (Blueprint $table) {
         $table->engine = 'InnoDB';
@@ -170,211 +177,214 @@ You may use the `engine` property on the schema builder to define the table's st
     });
 
 <a name="renaming-and-dropping-tables"></a>
-### Renaming / Dropping Tables
+### 重新命名與移除資料表
 
-To rename an existing database table, use the `rename` method:
+你可以使用 `rename` 方法來重新命名已存在的資料表：
 
     Schema::rename($from, $to);
 
-To drop an existing table, you may use the `drop` or `dropIfExists` methods:
+你可以使用 `drop` 或 `dropIfExists` 方法來移除已存在的資料表：
 
     Schema::drop('users');
 
     Schema::dropIfExists('users');
 
-#### Renaming Tables With Foreign Keys
+#### 重新命名已有外鍵的資料表
 
-Before renaming a table, you should verify that any foreign key constraints on the table have an explicit name in your migration files instead of letting Laravel assign a convention based name. Otherwise, the foreign key constraint name will refer to the old table name.
+在重新命名資料表前，你應該驗證在資料表上的任何外鍵約束在遷移檔案中都有明確的名稱，而不是讓 Laravel 發給你的基本約束名稱。否則外鍵約束名稱會沿用舊資料表。
 
 <a name="columns"></a>
-## Columns
+## 欄位
 
 <a name="creating-columns"></a>
-### Creating Columns
+### 建立欄位
 
-The `table` method on the `Schema` facade may be used to update existing tables. Like the `create` method, the `table` method accepts two arguments: the name of the table and a `Closure` that receives a `Blueprint` instance you may use to add columns to the table:
+在 `Schema` facade 上的 `table` 方法可被用於更新已存在的資料表。像是 `create` 方法、`table` 方法可接受兩個參數：資料表名稱和`閉包`，然後閉包可接受一個 `Blueprint` 實例，可用於新增欄位到資料表：
 
     Schema::table('users', function (Blueprint $table) {
         $table->string('email');
     });
 
-#### Available Column Types
+#### 可用的欄位型別
 
-Of course, the schema builder contains a variety of column types that you may specify when building your tables:
+當然，schema 建構器包含各種欄位類型，你可以在建構資料表的時候指定這些方法：
 
-Command  | Description
+指令  | 說明
 ------------- | -------------
-`$table->bigIncrements('id');`  |  Incrementing ID (primary key) using a "UNSIGNED BIG INTEGER" equivalent.
-`$table->bigInteger('votes');`  |  BIGINT equivalent for the database.
-`$table->binary('data');`  |  BLOB equivalent for the database.
-`$table->boolean('confirmed');`  |  BOOLEAN equivalent for the database.
-`$table->char('name', 4);`  |  CHAR equivalent with a length.
-`$table->date('created_at');`  |  DATE equivalent for the database.
-`$table->dateTime('created_at');`  |  DATETIME equivalent for the database.
-`$table->dateTimeTz('created_at');`  |  DATETIME (with timezone) equivalent for the database.
-`$table->decimal('amount', 5, 2);`  |  DECIMAL equivalent with a precision and scale.
-`$table->double('column', 15, 8);`  |  DOUBLE equivalent with precision, 15 digits in total and 8 after the decimal point.
-`$table->enum('choices', ['foo', 'bar']);` | ENUM equivalent for the database.
-`$table->float('amount', 8, 2);`  |  FLOAT equivalent for the database, 8 digits in total and 2 after the decimal point.
-`$table->geometry('column');`  | GEOMETRY equivalent for the database.
-`$table->geometryCollection('column');`  | GEOMETRYCOLLECTION equivalent for the database.
-`$table->increments('id');`  |  Incrementing ID (primary key) using a "UNSIGNED INTEGER" equivalent.
-`$table->integer('votes');`  |  INTEGER equivalent for the database.
-`$table->ipAddress('visitor');`  |  IP address equivalent for the database.
-`$table->json('options');`  |  JSON equivalent for the database.
-`$table->jsonb('options');`  |  JSONB equivalent for the database.
-`$table->lineString('column');`  |  LINESTRING equivalent for the database.
-`$table->longText('description');`  |  LONGTEXT equivalent for the database.
-`$table->macAddress('device');`  |  MAC address equivalent for the database.
-`$table->mediumIncrements('id');`  |  Incrementing ID (primary key) using a "UNSIGNED MEDIUM INTEGER" equivalent.
-`$table->mediumInteger('numbers');`  |  MEDIUMINT equivalent for the database.
-`$table->mediumText('description');`  |  MEDIUMTEXT equivalent for the database.
-`$table->morphs('taggable');`  |  Adds unsigned INTEGER `taggable_id` and STRING `taggable_type`.
-`$table->multiLineString('column');`  |  MULTILINESTRING equivalent for the database.
-`$table->multiPoint('column');`  |  MULTIPOINT equivalent for the database.
-`$table->multiPolygon('column');`  |  MULTIPOLYGON equivalent for the database.
-`$table->nullableMorphs('taggable');`  |  Nullable versions of the `morphs()` columns.
-`$table->nullableTimestamps();`  |  Nullable versions of the `timestamps()` columns.
-`$table->point('column');`  | POINT equivalent for the database.
-`$table->polygon('column');`  | POLYGON equivalent for the database.
-`$table->rememberToken();`  |  Adds `remember_token` as VARCHAR(100) NULL.
-`$table->smallIncrements('id');`  |  Incrementing ID (primary key) using a "UNSIGNED SMALL INTEGER" equivalent.
-`$table->smallInteger('votes');`  |  SMALLINT equivalent for the database.
-`$table->softDeletes();`  |  Adds nullable `deleted_at` column for soft deletes.
-`$table->string('email');`  |  VARCHAR equivalent column.
-`$table->string('name', 100);`  |  VARCHAR equivalent with a length.
-`$table->text('description');`  |  TEXT equivalent for the database.
-`$table->time('sunrise');`  |  TIME equivalent for the database.
-`$table->timeTz('sunrise');`  |  TIME (with timezone) equivalent for the database.
-`$table->timestamp('added_on');`  |  TIMESTAMP equivalent for the database.
-`$table->timestampTz('added_on');`  |  TIMESTAMP (with timezone) equivalent for the database.
-`$table->timestamps();`  |  Adds nullable `created_at` and `updated_at` columns.
-`$table->timestampsTz();`  |  Adds nullable `created_at` and `updated_at` (with timezone) columns.
-`$table->tinyInteger('numbers');`  |  TINYINT equivalent for the database.
-`$table->unsignedBigInteger('votes');`  |  Unsigned BIGINT equivalent for the database.
-`$table->unsignedInteger('votes');`  |  Unsigned INT equivalent for the database.
-`$table->unsignedMediumInteger('votes');`  |  Unsigned MEDIUMINT equivalent for the database.
-`$table->unsignedSmallInteger('votes');`  |  Unsigned SMALLINT equivalent for the database.
-`$table->unsignedTinyInteger('votes');`  |  Unsigned TINYINT equivalent for the database.
-`$table->uuid('id');`  |  UUID equivalent for the database.
+`$table->bigIncrements('id');`  |  自動遞增相當於 UNSIGNED BIGINT（主鍵）欄位。
+`$table->bigInteger('votes');`  |  相當於 BIGINT 欄位。
+`$table->binary('data');`  |  相當於 BLOB 欄位。
+`$table->boolean('confirmed');`  |  相當於 BOOLEAN 欄位
+`$table->char('name', 100);`  |  相當於 CHAR 欄位並可選擇長度。
+`$table->date('created_at');`  |  相當於 DATE 欄位。
+`$table->dateTime('created_at');`  |  相當於 DATETIME 對等欄位。
+`$table->dateTimeTz('created_at');`  |  相當於 DATETIME （含時區） 欄位。
+`$table->decimal('amount', 8, 2);`  |  相當於 DECIMAL 欄位，並帶有精度（整數位長度）與基數（小數點長度）。
+`$table->double('amount', 8, 2);`  |  相當於 DOUBLE 欄位，並帶有精度（整數位長度）與基數（小數點長度）。
+`$table->enum('level', ['easy', 'hard']);`  |  相當於 ENUM 欄位。
+`$table->float('amount', 8, 2);`  |  相當於 FLOAT 欄位，並帶有精度（整數位長度）與基數（小數點長度）。
+`$table->geometry('positions');`  |  相當於 GEOMETRY 欄位。
+`$table->geometryCollection('positions');`  |  相當於 GEOMETRYCOLLECTION 欄位。
+`$table->increments('id');`  |  自動遞增相當於 UNSIGNED INTEGER（主鍵）欄位。
+`$table->integer('votes');`  |  相當於 INTEGER 欄位。
+`$table->ipAddress('visitor');`  |  相當於 IP 位址欄位。
+`$table->json('options');`  |  相當於 JSON 欄位。
+`$table->jsonb('options');`  |  相當於 JSONB 欄位。
+`$table->lineString('positions');`  |  相當於 LINESTRING 欄位。
+`$table->longText('description');`  |  相當於 LONGTEXT 欄位。
+`$table->macAddress('device');`  |  相當於 MAC 位址欄位。
+`$table->mediumIncrements('id');`  |  自動遞增相當於 UNSIGNED MEDIUMINT（主鍵）欄位。
+`$table->mediumInteger('votes');`  |  相當於 MEDIUMINT 欄位。
+`$table->mediumText('description');`  |  相當於 MEDIUMTEXT 欄位。
+`$table->morphs('taggable');`  |  新增相當於 `taggable_id` 的 UNSIGNED INTEGER 和 `taggable_type` 的 VARCHAR 欄位。
+`$table->multiLineString('positions');`  |  相當於 MULTILINESTRING 欄位。
+`$table->multiPoint('positions');`  |  相當於 MULTIPOINT 欄位。
+`$table->multiPolygon('positions');`  |  相當於 MULTIPOLYGON 欄位。
+`$table->nullableMorphs('taggable');`  |  新增可以 null 的 `morphs()` 欄位版本。
+`$table->nullableTimestamps();`  |  新增可以 null 的 `timestamps()` 欄位版本。
+`$table->point('position');`  |  相當於 POINT 欄位。
+`$table->polygon('positions');`  |  相當於 POLYGON 欄位。
+`$table->rememberToken();`  |  相當於新增可以 null 的 `remember_token` VARCHAR(100) 欄位。
+`$table->smallIncrements('id');`  |  自動遞增相當於 UNSIGNED SMALLINT（主鍵）欄位。
+`$table->smallInteger('votes');`  |  相當於 SMALLINT 欄位。
+`$table->softDeletes();`  |  相當於為緩刪除新增可以 null 的 `deleted_at` 時間戳欄位。
+`$table->softDeletesTz();`  |  相當於為緩刪除新增可以 null 的 `deleted_at` 時間戳（含時區）欄位。
+`$table->string('name', 100);`  |  相當於 VARCHAR 欄位並可選擇長度。
+`$table->text('description');`  |  相當於 TEXT 欄位。
+`$table->time('sunrise');`  |  相當於 TIME 欄位。
+`$table->timeTz('sunrise');`  |  相當於 TIME（含時區）欄位。
+`$table->timestamp('added_on');`  |  相當於 TIMESTAMP 欄位。
+`$table->timestampTz('added_on');`  |  相當於 TIMESTAMP（含時區）欄位。
+`$table->timestamps();`  |  相當於新增可以 null 的 `created_at` 和 `updated_at` 時間戳欄位。
+`$table->timestampsTz();`  |  相當於新增可以 null 的 `created_at` 和 `updated_at` 時間戳（含時區）欄位。
+`$table->tinyIncrements('id');`  |  自動遞增相當於 UNSIGNED TINYINT（主鍵）欄位。
+`$table->tinyInteger('votes');`  |  相當於 TINYINT 欄位欄位。
+`$table->unsignedBigInteger('votes');`  |  相當於 UNSIGNED BIGINT 欄位。
+`$table->unsignedDecimal('amount', 8, 2);`  |  相當於 UNSIGNED DECIMAL 欄位，並帶有精度（整數位長度）與基數（小數點長度）。
+`$table->unsignedInteger('votes');`  |  相當於 UNSIGNED INTEGER 欄位。
+`$table->unsignedMediumInteger('votes');`  |  相當於 UNSIGNED MEDIUMINT 欄位。
+`$table->unsignedSmallInteger('votes');`  |  相當於 UNSIGNED SMALLINT 欄位。
+`$table->unsignedTinyInteger('votes');`  |  相當於 UNSIGNED TINYINT 欄位。
+`$table->uuid('id');`  |  相當於 UUID 欄位。
 
 <a name="column-modifiers"></a>
-### Column Modifiers
+### 欄位修飾
 
-In addition to the column types listed above, there are several column "modifiers" you may use while adding a column to a database table. For example, to make the column "nullable", you may use the `nullable` method:
+除了以上的欄位類型清單，這有幾個欄位「修飾」可以用於新增欄位到資料表。例如，你可以使用 `nullable` 方法來使欄位「nullable」：
 
     Schema::table('users', function (Blueprint $table) {
         $table->string('email')->nullable();
     });
 
-Below is a list of all the available column modifiers. This list does not include the [index modifiers](#creating-indexes):
+以下是所有可用的欄位修飾清單，這個清單不含 [索引修飾](#creating-indexes)：
 
-Modifier  | Description
+修飾方法  | 說明
 ------------- | -------------
-`->after('column')`  |  Place the column "after" another column (MySQL Only)
-`->comment('my comment')`  |  Add a comment to a column (MySQL Only)
-`->default($value)`  |  Specify a "default" value for the column
-`->first()`  |  Place the column "first" in the table (MySQL Only)
-`->nullable()`  |  Allow NULL values to be inserted into the column
-`->storedAs($expression)`  |  Create a stored generated column (MySQL Only)
-`->unsigned()`  |  Set `integer` columns to `UNSIGNED`
-`->virtualAs($expression)`  |  Create a virtual generated column (MySQL Only)
+`->after('column')`  |  將該欄位放置其他欄位「之後」。（MySQL 限定）
+`->autoIncrement()`  |  設定 INTEGER 欄位能自動遞增（主鍵）
+`->charset('utf8')`  |  為欄位指定字元編碼。（MySQL 限定）
+`->collation('utf8_unicode_ci')`  |  為欄位指定序。（MySQL 與 SQL 伺服器限定）
+`->comment('my comment')`  |  為欄位新增註解。 （MySQL 限定）
+`->default($value)`  |  為欄位指定「預設」值。
+`->first()`  |  將此欄位放置於資料表的「第一個」。（MySQL 限定）
+`->nullable($value = true)`  |  讓欄位預設允許寫入 NULL 值。
+`->storedAs($expression)`  |  建立一個儲存產生的欄位。（MySQL 限定）
+`->unsigned()`  |  設定 INTEGER 欄位為 UNSIGNED。 （MySQL 限定）
+`->useCurrent()`  |  設定 TIMESTAMP 欄位要使用 CURRENT_TIMESTAMP 作為預設值。
+`->virtualAs($expression)`  |  建立一個虛擬產生的欄位。（MySQL 限定）
 
-<a name="changing-columns"></a>
 <a name="modifying-columns"></a>
-### Modifying Columns
+### 修改欄位
 
-#### Prerequisites
+#### 必要條件
 
-Before modifying a column, be sure to add the `doctrine/dbal` dependency to your `composer.json` file. The Doctrine DBAL library is used to determine the current state of the column and create the SQL queries needed to make the specified adjustments to the column:
+在修改欄位之前，請務必在你的 `composer.json` 檔案新增 `doctrine/dbal` 依賴。Doctrine DBAL 函式庫被用於判斷當前欄位狀態與建立調整指定欄位的 SQL 查詢：
 
     composer require doctrine/dbal
 
-#### Updating Column Attributes
+#### 更新欄位屬性
 
-The `change` method allows you to modify some existing column types to a new type or modify the column's attributes. For example, you may wish to increase the size of a string column. To see the `change` method in action, let's increase the size of the `name` column from 25 to 50:
+`change` 方法可以讓你修改一些已存在的欄位類型或修改欄位屬性。例如，你可能希望增加字串欄位的長度。要查看 `change` 方法的作用，讓我們將 `name` 欄位的大小從 25 改成 50：
 
     Schema::table('users', function (Blueprint $table) {
         $table->string('name', 50)->change();
     });
 
-We could also modify a column to be nullable:
+我們也能將欄位修改為 nullable：
 
     Schema::table('users', function (Blueprint $table) {
         $table->string('name', 50)->nullable()->change();
     });
 
-> {note} The following column types can not be "changed": char, double, enum, mediumInteger, timestamp, tinyInteger, ipAddress, json, jsonb, macAddress, mediumIncrements, morphs, nullableMorphs, nullableTimestamps, softDeletes, timeTz, timestampTz, timestamps, timestampsTz, unsignedMediumInteger, unsignedTinyInteger, uuid.
+> {note} 以下欄位類型不能被「更改」：char、double、enum、mediumInteger、timestamp、tinyInteger、ipAddress、json、jsonb、macAddress、mediumIncrements、morphs、nullableMorphs、nullableTimestamps、softDeletes、timeTz、timestampTz、timestamps、timestampsTz、unsignedMediumInteger、unsignedTinyInteger、uuid。
 
-<a name="renaming-columns"></a>
-#### Renaming Columns
+#### 重新命名欄位
 
-To rename a column, you may use the `renameColumn` method on the Schema builder. Before renaming a column, be sure to add the `doctrine/dbal` dependency to your `composer.json` file:
+你可以在 Schema 建構器上使用 `renameColumn` 方法來重新命名欄位。再重新命名欄位之前，請務必在你的 `composer.json` 檔案上新增 `doctrine/dbal` 依賴：
 
     Schema::table('users', function (Blueprint $table) {
         $table->renameColumn('from', 'to');
     });
 
-> {note} Renaming any column in a table that also has a column of type `enum` is not currently supported.
+> {note} 目前不支援修改 `enum` 類型的欄位名稱。
 
 <a name="dropping-columns"></a>
-### Dropping Columns
+### 移除欄位
 
-To drop a column, use the `dropColumn` method on the Schema builder. Before dropping columns from a SQLite database, you will need to add the `doctrine/dbal` dependency to your `composer.json` file and run the `composer update` command in your terminal to install the library:
+你可以在 Schema 建構器上使用 `dropColumn` 方法來移除欄位。從 SQLite 資料庫移除欄位之前，你會需要在你的 `composer.json` 檔案上新增 `doctrine/dbal` 依賴，並在你的終端機執行 `composer update`來安裝該函式庫：
 
     Schema::table('users', function (Blueprint $table) {
         $table->dropColumn('votes');
     });
 
-You may drop multiple columns from a table by passing an array of column names to the `dropColumn` method:
+你可以從資料表的上傳入欄位名稱陣列到 `dropColumn` 方法來移除多個欄位：
 
     Schema::table('users', function (Blueprint $table) {
         $table->dropColumn(['votes', 'avatar', 'location']);
     });
 
-> {note} Dropping or modifying multiple columns within a single migration while using a SQLite database is not supported.
+> {note} 當使用 SQLite 資料庫時，並不支援在單一遷移中移除或修改多個欄位。
 
 <a name="indexes"></a>
-## Indexes
+## 索引
 
 <a name="creating-indexes"></a>
-### Creating Indexes
+### 建立索引
 
-The schema builder supports several types of indexes. First, let's look at an example that specifies a column's values should be unique. To create the index, we can simply chain the `unique` method onto the column definition:
+schema 建構器支援幾個索引類型。首先，讓我們看一下指定欄位的值必須是 unique 的範例。要建立索引，我們可以只鏈結 `unique` 方法到欄位定義上：
 
     $table->string('email')->unique();
 
-Alternatively, you may create the index after defining the column. For example:
+或者，你可以定義欄位後才建立索引。例如：
 
     $table->unique('email');
 
-You may even pass an array of columns to an index method to create a compound index:
+你甚至可以將欄位的陣列傳入 `index` 方法來建立複合索引：
 
     $table->index(['account_id', 'created_at']);
 
-Laravel will automatically generate a reasonable index name, but you may pass a second argument to the method to specify the name yourself:
+Laravel 會自動產生一個合理的索引名稱，但你可以指定你要的名稱作為第二參數，並傳入該方法：
 
-    $table->index('email', 'my_index_name');
+    $table->unique('email', 'unique_email');
 
-#### Available Index Types
+#### 可用的索引類型
 
-Command  | Description
+指令  | 說明
 ------------- | -------------
-`$table->primary('id');`  |  Add a primary key.
-`$table->primary(['first', 'last']);`  |  Add composite keys.
-`$table->unique('email');`  |  Add a unique index.
-`$table->unique('state', 'my_index_name');`  |  Add a custom index name.
-`$table->unique(['first', 'last']);`  |  Add a composite unique index.
-`$table->index('state');`  |  Add a basic index.
+`$table->primary('id');`  |  新增主鍵。
+`$table->primary(['id', 'parent_id']);`  |  新增複合鍵。
+`$table->unique('email');`  |  新增唯一的索引。
+`$table->index('state');`  |  新增基本的索引。
+`$table->spatialIndex('location');`  |  新增空間索引。（MySQL 限定）
 
-#### Index Lengths & MySQL / MariaDB
+#### 索引長度與 MySQL 與 MariaDB
 
-Laravel uses the `utf8mb4` character set by default, which includes support for storing "emojis" in the database. If you are running a version of MySQL older than the 5.7.7 release or MariaDB older than the 10.2.2 release, you may need to manually configure the default string length generated by migrations in order for MySQL to create indexes for them. You may configure this by calling the `Schema::defaultStringLength` method within your `AppServiceProvider`:
+Laravel 預設使用 `utf8mb4` 字元編碼， 包括支援在資料庫中儲存「表情符號」。如果你執行的 MySQL 版本比 5.5.7 版本還舊，或 MariaDB 還沒升級至 10.2.2 以上，又想要在遷移被產生時 MySQL 能順利的為它們建立索引，你需要手動設定預設字串長度。你可以在 `AppServiceProvider` 中呼叫 `Schema::defaultStringLength` 方法來設定：
 
     use Illuminate\Support\Facades\Schema;
 
     /**
-     * Bootstrap any application services.
+     * 引導任何應用程式服務。
      *
      * @return void
      */
@@ -383,29 +393,29 @@ Laravel uses the `utf8mb4` character set by default, which includes support for 
         Schema::defaultStringLength(191);
     }
 
-Alternatively, you may enable the `innodb_large_prefix` option for your database. Refer to your database's documentation for instructions on how to properly enable this option.
+或者，你可以為資料庫啟用 `innodb_large_prefix` 選項。關於如何啟用這個選項的說明，請參考你所使用的資料庫文件。
 
 <a name="dropping-indexes"></a>
-### Dropping Indexes
+### 移除索引
 
-To drop an index, you must specify the index's name. By default, Laravel automatically assigns a reasonable name to the indexes. Simply concatenate the table name, the name of the indexed column, and the index type. Here are some examples:
+要移除索引，你必須指定該索引的名稱。Laravel 預設會自動為索引分配一個合理的名稱。只要將資料表名稱、索引欄位名稱和索引類型連接再一起。這裡有一些範例：
 
-Command  | Description
+指令  | 說明
 ------------- | -------------
-`$table->dropPrimary('users_id_primary');`  |  Drop a primary key from the "users" table.
-`$table->dropUnique('users_email_unique');`  |  Drop a unique index from the "users" table.
-`$table->dropIndex('geo_state_index');`  |  Drop a basic index from the "geo" table.
+`$table->dropPrimary('users_id_primary');`  |  從「users」資料表移除主鍵。
+`$table->dropUnique('users_email_unique');`  |  從「users」資料表移除唯一索引。
+`$table->dropIndex('geo_state_index');`  |  從「geo」資料表移除基本的索引。
 
-If you pass an array of columns into a method that drops indexes, the conventional index name will be generated based on the table name, columns and key type:
+如果你傳入欄位陣列到 `dropIndex` 方法，會根據資料表名稱、欄位和鍵的類型來產生要移除的預設索引名稱：
 
     Schema::table('geo', function (Blueprint $table) {
-        $table->dropIndex(['state']); // Drops index 'geo_state_index'
+        $table->dropIndex(['state']); // 移除 'geo_state_index' 索引
     });
 
 <a name="foreign-key-constraints"></a>
-### Foreign Key Constraints
+### 外鍵約束
 
-Laravel also provides support for creating foreign key constraints, which are used to force referential integrity at the database level. For example, let's define a `user_id` column on the `posts` table that references the `id` column on a `users` table:
+Laravel 也為建立外鍵約束提供支援，這是用於在資料庫層面強制參考完整性。例如，讓我們定義 posts 資料表內有個 user_id 欄位要參考至 users 資料表的 id 欄位：
 
     Schema::table('posts', function (Blueprint $table) {
         $table->integer('user_id')->unsigned();
@@ -413,21 +423,21 @@ Laravel also provides support for creating foreign key constraints, which are us
         $table->foreign('user_id')->references('id')->on('users');
     });
 
-You may also specify the desired action for the "on delete" and "on update" properties of the constraint:
+你也可以指定約束的「on delete」及「on update」作為所需的操作：
 
     $table->foreign('user_id')
           ->references('id')->on('users')
           ->onDelete('cascade');
 
-To drop a foreign key, you may use the `dropForeign` method. Foreign key constraints use the same naming convention as indexes. So, we will concatenate the table name and the columns in the constraint then suffix the name with "_foreign":
+要移除外鍵，你可以使用 dropForeign 方法。外鍵約束與索引採用相同的命名方式。所以，我們可以連結資料表明與約束的欄位，接著在該名稱加上「_foreign」後綴：
 
     $table->dropForeign('posts_user_id_foreign');
 
-Or, you may pass an array value which will automatically use the conventional constraint name when dropping:
+或者你可以傳入陣列值，在移除時會自動使用預設約束名稱：
 
     $table->dropForeign(['user_id']);
 
-You may enable or disable foreign key constraints within your migrations by using the following methods:
+你可以在你的遷移中使用下列方法來啟用或停用外鍵約束：
 
     Schema::enableForeignKeyConstraints();
 


### PR DESCRIPTION
## **Translate `migrations.md` (v5.5)**

1. 已同步原始文件最新的修改。
2. schema builder 算是專有名詞，故翻 Schema 建構器，其餘 Schema 翻譯為結構。
3. 在欄位類型清單的地方，有遇到 precision (total digits) and scale (decimal digits) 這種不太會翻的句子，麻煩有錯請糾正QAQ
