### PR TITLE
Translate eloquent.md (v5.5)

### DIFF
--- a/eloquent.md
+++ b/eloquent.md
@@ -6,8 +6,8 @@
 - [取得模型](#retrieving-models)
     - [集合](#collections)
     - [分塊結果](#chunking-results)
-- [取得單一模型或合計](#retrieving-single-models)
-    - [取得合計](#retrieving-aggregates)
+- [取得單一模型或 Aggregate](#retrieving-single-models)
+    - [取得 Aggregate](#retrieving-aggregates)
 - [插入與更新模型](#inserting-and-updating-models)
     - [插入](#inserts)
     - [更新](#updates)
@@ -27,7 +27,7 @@
 
 Laravel 的 Eloquent ORM 提供了漂亮、簡潔的 ActiveRecord 實作來和資料庫互動。每個資料庫表有一個對應的「模型」可以用來跟資料表互動。你可以透過模型查詢資料表內的資料，以及新增記錄到資料表中。
 
-在開始之前，請確認有設定你的資料庫連結在 `config/database.php` 檔案內。更多資料庫的設定資訊，請查看[資料庫設定](/docs/{{version}}/database#configuration)。
+在開始之前，一定要在 `config/database.php` 中設定一個資料庫連接。更多資料庫的設定資訊，請查看[資料庫設定](/docs/{{version}}/database#configuration)。
 
 <a name="defining-models"></a>
 ## 定義模型
@@ -38,7 +38,7 @@ Laravel 的 Eloquent ORM 提供了漂亮、簡潔的 ActiveRecord 實作來和�
 
     php artisan make:model User
 
-假設當你生成一個模型時，想要產生一個[資料庫遷移](/docs/{{version}}/schema#database-migrations)，可以使用 `--migration` 或 `-m` 選項：
+假設當你產生一個模型時，想要產生一個[資料庫遷移](/docs/{{version}}/schema#database-migrations)，可以使用 `--migration` 或 `-m` 選項：
 
     php artisan make:model User --migration
 
@@ -60,7 +60,7 @@ Laravel 的 Eloquent ORM 提供了漂亮、簡潔的 ActiveRecord 實作來和�
         //
     }
 
-#### 資料表名字
+#### 資料表名稱
 
 請注意，我們並沒有告訴 Eloquent `Flight` 模型該使用哪一個資料表。依照慣例，除非明確地指定其他名稱，不然類別的小寫、底線、複數形式會拿來當作資料表的表單名稱。所以，這個案例中，Eloquent 將會假設 `Flight` 模型儲存記錄在 `flights` 資料表。你可以在模型上定義一個 `table` 屬性，用來指定自訂的資料表：
 
@@ -86,7 +86,7 @@ Eloquent 也會假設每個資料表有一個主鍵欄位叫做 `id`。你可以
 
 此外，Eloquent 會假設主鍵是一個遞增的整數值，這表示預設的主鍵位自動轉換成 `int`。如果你希望使用非遞增或非數字的主鍵，務必把模型上的 `public $incrementing` 屬性設定為 `false`。如果你的主鍵不是一個整數，你應該將模型上的 `protected $keyType` 屬性設定為 `string`。
 
-#### 時間戳
+#### 時間戳記
 
 預設的 Eloquent 會預期你的資料表會有 `created_at` 和 `updated_at` 欄位。如果你不希望 Eloquent 自動管理這些欄位，請將模型上的 `$timestamps` 屬性設定為 `false`：
 
@@ -99,7 +99,7 @@ Eloquent 也會假設每個資料表有一個主鍵欄位叫做 `id`。你可以
     class Flight extends Model
     {
         /**
-         * 表示模型使否應該被戳記時間。
+         * 說明模型是否應該被戳記時間。
          *
          * @var bool
          */
@@ -124,7 +124,7 @@ Eloquent 也會假設每個資料表有一個主鍵欄位叫做 `id`。你可以
         protected $dateFormat = 'U';
     }
 
-如果你需要自訂欄位名稱，並用來儲存時間戳，你可以在模型中設定 `CREATED_AT` 和 `UPDATED_AT` 常數：
+如果你需要自訂欄位名稱，並用來儲存時間戳記，你可以在模型中設定 `CREATED_AT` 和 `UPDATED_AT` 常數：
 
     <?php
 
@@ -189,7 +189,7 @@ Eloquent 的 `all` 方法會回傳在模型資料表中所有的結果。由於�
         return $flight->cancelled;
     });
 
-當然，你也可以只對集合執行迴圈，像是疊代陣列：
+當然，你也可以像陣列一樣簡單地遍歷集合：
 
     foreach ($flights as $flight) {
         echo $flight->name;
@@ -217,7 +217,7 @@ Eloquent 的 `all` 方法會回傳在模型資料表中所有的結果。由於�
     }
 
 <a name="retrieving-single-models"></a>
-## 取得單一模型或合計
+## 取得單一模型或 Aggregate
 
 當然，除了取得給定資料表的所有記錄，你還可以使用 `find` 或 `first` 來取得單一記錄。這些方法會回傳單一模型實例，而非回傳模型的集合：
 
@@ -231,24 +231,24 @@ Eloquent 的 `all` 方法會回傳在模型資料表中所有的結果。由於�
 
     $flights = App\Flight::find([1, 2, 3]);
 
-#### 因找不到而拋出的例外
+#### Not Found 拋出例外
 
-有時你可能希望因為找不到模型而拋出例外。這在路由或控制器特別好用。`findOrFail` 和 `firstOrFail` 方法會取得查詢的第一個結果。然而，如果未能找到結果，`Illuminate\Database\Eloquent\ModelNotFoundException` 會拋出例外：
+有時你可能希望因為找不到模型而拋出例外。這在路由或控制器中特別有用。`findOrFail` 和 `firstOrFail` 方法會取得查詢的第一個結果。然而，如果未能找到結果，`Illuminate\Database\Eloquent\ModelNotFoundException` 會拋出例外：
 
     $model = App\Flight::findOrFail(1);
 
     $model = App\Flight::where('legs', '>', 100)->firstOrFail();
 
-如果沒抓到例外，則會自動發送 `404` HTTP 會應給使用者。在使用這些方法時，不必仔細撰寫檢查要回傳的 `404` 回應：
+如果沒有捕獲例外，則會自動發送 `404` HTTP 會應給使用者。在使用這些方法時，不必仔細撰寫檢查要回傳的 `404` 回應：
 
     Route::get('/api/flights/{id}', function ($id) {
         return App\Flight::findOrFail($id);
     });
 
 <a name="retrieving-aggregates"></a>
-### 取得合計
+### 取得 Aggregate
 
-你也可以使用[查詢建構器](/docs/{{version}}/queries)提供的 `count`、`sum`、`max` 和其他[合計方法](/docs/{{version}}/queries#aggregates)。這些方法會回傳適當的純量值，而不是完整的模型實例：
+你也可以使用[查詢建構器](/docs/{{version}}/queries)提供的 `count`、`sum`、`max` 和其他 [aggregate 方法](/docs/{{version}}/queries#aggregates)。這些方法會回傳確切的純量值，而不是完整的模型實例：
 
     $count = App\Flight::where('active', 1)->count();
 
@@ -318,12 +318,11 @@ Eloquent 的 `all` 方法會回傳在模型資料表中所有的結果。由於�
 <a name="mass-assignment"></a>
 ### 批量賦值
 
-你也可以在同一行上使用 `create` 方法來儲存新模型。被插入的模型實例會從該方法回傳給你。然而在這之前，你會需要在模型上指定 `fillable` 或 `guarded` 這兩種屬性選擇一種，因為所有的 Eloquent 模型預設會針對批量賦值作保護。
+你也可以在使用 `create` 方法來儲存一個新的模型。被插入的模型實例會從該方法回傳給你。然而，在這之前，你將需要在你的模型上指定一個 `fillable` 或是 `guarded` 屬性，所有的 Eloquent 模型預設會針對批量賦值作保護。
 
-當使用者傳入的請求有你沒料想到的 HTTP 參數，並且該參數會非預期竄改資料庫中的欄位，會發生批量賦值的漏洞。例如，一個惡意的使用者硬是要發送包含 `is_admin` 參數的 HTTP 請求，然後映射到你模型的 `create` 方法，藉此同意使用者升級到管理者權限。
+當使用者透過請求傳入一個非預期的 HTTP 參數時，該參數會非預期竄改資料庫中的欄位，發生批量賦值的漏洞。例如，一個惡意的使用者透過 HTTP 請求發送一個 `is_admin` 參數，接著被傳送到你模型的 `create` 方法，讓使用者可以把自己提升為一位管理員。
 
-所以，你應該開始定義想要被批量賦值的模型屬性。你可以在模型上使用 `$fillable` 屬性來達到這點。例如讓我們實際去做 `Flight` 模型的 `name`
-屬性的批量賦值：
+所以，你應該開始定義想要被批量賦值的模型屬性。你可以在模型上使用 `$fillable` 屬性來達到這點。例如讓我們實際去做 `Flight` 模型的 `name` 屬性的批量賦值：
 
     <?php
 
@@ -383,7 +382,7 @@ Eloquent 的 `all` 方法會回傳在模型資料表中所有的結果。由於�
 
 #### `firstOrCreate` 和 `firstOrNew`
 
-你可以透過批量賦值屬性到另外兩種方法來建立模型：`firstOrCreate` 和 `firstOrNew`。`firstOrCreate` 方法會嘗試使用給定的欄位與值來找資料庫記錄。如果在資料庫中無法找到該模型，會從屬性的第一個參數以及那些可選的參數第二個參數中插入一筆記錄。
+你還可以使用其他兩種方法透過批量賦值屬性來建立模型：`firstOrCreate` 和 `firstOrNew`。`firstOrCreate` 方法會嘗試使用給定的欄位與值來找資料庫記錄。如果在資料庫中無法找到該模型，會從屬性的第一個參數以及那些可選的參數第二個參數中插入一筆記錄。
 
 `firstOrNew` 方法類似 `firstOrCreate`，會嘗試在資料庫查詢符合給定屬性的記錄。然而，如果沒找到模型，將會回傳一個新模型。該注意 `firstOrNew` 回傳的模型還未存到資料庫，你還需要手動呼叫 `save` 來儲存它：
 
@@ -423,7 +422,7 @@ Eloquent 的 `all` 方法會回傳在模型資料表中所有的結果。由於�
 
     $flight->delete();
 
-#### 依鍵號刪除已存在的模型
+#### 透過主鍵刪除存在的模型
 
 在上述範例中，我們會在呼叫 `delete` 方法前，從資料庫取得模型。然而，如果你知道該模型的主鍵，你可以沒有取得模型就刪除它。呼叫 `destroy` 方法來達成：
 
@@ -433,7 +432,7 @@ Eloquent 的 `all` 方法會回傳在模型資料表中所有的結果。由於�
 
     App\Flight::destroy(1, 2, 3);
 
-#### 依查詢來刪除模型
+#### 透過查詢來刪除模型
 
 當然，你也可以在一組模型上執行刪除的語法。在這個範例中，我們會刪除所有被標記無效的航班。批量刪除類似批量更新，不會觸發刪除模型的任何模型事件：
 
@@ -473,7 +472,7 @@ Eloquent 的 `all` 方法會回傳在模型資料表中所有的結果。由於�
 
 現在，當你在模型上呼叫 `delete` 方法時，`deleted_at` 欄位會設定當前日期與時間。還有，查詢有使用軟刪除的模型時，被軟刪除的模型會自動從所有查詢結果中排除。
 
-若要確定給定的模型實例是否被軟刪除，請使用 `trashed` 方法：
+如果要確定給定的模型實例是否被軟刪除，請使用 `trashed` 方法：
 
     if ($flight->trashed()) {
         //
@@ -502,13 +501,13 @@ Eloquent 的 `all` 方法會回傳在模型資料表中所有的結果。由於�
                     ->where('airline_id', 1)
                     ->get();
 
-#### 取得被軟刪除的模型
+#### 恢復被軟刪除的模型
 
 有時你可能希望「取消刪除」被軟刪除的模型。要把被軟刪除的資料恢復到一般狀態，請在模型實例上使用 `restore` 方法：
 
     $flight->restore();
 
-你也可以在查詢中使用 `restore` 方法來快速恢復多筆資料。就像其他「批量」操作，這不會在恢復資料的時候觸發任何模型實踐：
+你也可以在查詢中使用 `restore` 方法來快速恢復多筆資料。就像其他「批量」操作，這不會在恢復資料的時候觸發任何模型實例：
 
     App\Flight::withTrashed()
             ->where('airline_id', 1)
@@ -529,14 +528,14 @@ Eloquent 的 `all` 方法會回傳在模型資料表中所有的結果。由於�
     $flight->history()->forceDelete();
 
 <a name="query-scopes"></a>
-## 查詢 Scopes
+## 查詢 Scope
 
 <a name="global-scopes"></a>
-### 全域的 Scopes
+### 全域的 Scope
 
-全域的 Scopes 可以讓你為給定模型新增條件到所有查詢。Laravel 自己的[軟刪除](#soft-deleting) 功能利用全域的 Scopes 能從資料庫中只取出「未刪除」模型。撰寫自己全域的 Scopes 能提供更方便且簡單的方式來確保給定模型的每個查詢都能受到一定的限制。
+全域的 Scope 可以讓你為給定模型新增條件到所有查詢。Laravel 自己的[軟刪除](#soft-deleting) 功能利用全域的 Scope 能從資料庫中只取出「未刪除」模型。撰寫自己全域的 Scope 能提供更方便且簡單的方式來確保給定模型的每個查詢都能受到一定的限制。
 
-#### 撰寫全域的 Scopes
+#### 撰寫全域的 Scope
 
 撰寫全域的 scope 是相當簡單的事情。定義實作 `Illuminate\Database\Eloquent\Scope` 介面的類別。這個介面會要求你實作 `apply` 方法，`apply` 方法可以根據需要來新增 `where` 來查詢：
 
@@ -565,7 +564,7 @@ Eloquent 的 `all` 方法會回傳在模型資料表中所有的結果。由於�
 
 > {tip} 如果你的全域的 Scope 正在新增欄位到查詢的 select 子句，你應該使用 `addSelect` 方法，而非 `select`。這可避免不小心換掉現有的查詢 select 子句。
 
-#### 應用在全域的 Scopes
+#### 應用在全域的 Scope
 
 要指派全域的 Scope 到模型，你應該覆寫給定模型的 `boot` 方法並使用 `addGlobalScope` 方法：
 
@@ -595,9 +594,9 @@ Eloquent 的 `all` 方法會回傳在模型資料表中所有的結果。由於�
 
     select * from `users` where `age` > 200
 
-#### 匿名全域的 Scopes
+#### 匿名全域的 Scope
 
-Eloquent 也可以讓你使用閉包來定義全域的，這在簡單的作用域內相當的有用，但是不保證在獨立的類別內：
+Eloquent 也可以讓你使用閉包來定義全域的，這對於簡單的作用域內相當的有用，但是不保證在獨立的類別內：
 
     <?php
 
@@ -623,26 +622,26 @@ Eloquent 也可以讓你使用閉包來定義全域的，這在簡單的作用�
         }
     }
 
-#### 移除全域的 Scopes
+#### 移除全域的 Scope
 
 如果你想要為給定的查詢移除全域的 Scope，你可以使用 `withoutGlobalScope` 方法。該方法接受全域的 Scope 的類別名稱作為唯一參數：
 
     User::withoutGlobalScope(AgeScope::class)->get();
 
-如果你想要移除幾個或甚至所有的全域的 Scopes，你可以使用 `withoutGlobalScopes` 方法：
+如果你想要移除幾個或甚至所有的全域的 Scope，你可以使用 `withoutGlobalScopes` 方法：
 
-    // 移除所有的全域的 Scopes...
+    // 移除所有的全域的 Scope...
     User::withoutGlobalScopes()->get();
 
-    // 移除某些全域的 Scopes...
+    // 移除某些全域的 Scope...
     User::withoutGlobalScopes([
         FirstScope::class, SecondScope::class
     ])->get();
 
 <a name="local-scopes"></a>
-### 局部的 Scopes
+### 局部的 Scope
 
-局部的 Scopes 讓你定義限制的共用集合，它可以輕鬆地在你的應用程式重複使用。例如，你可能需要頻繁地取得所有被認為是「受歡迎的」使用者。要定義的 Scopes，必須簡單地在 Eloquent 模型方法前面加上前綴 `scope`
+局部的 Scope 讓你定義限制的共用集合，它可以輕鬆地在你的應用程式重複使用。例如，你可能需要頻繁地取得所有被認為是「受歡迎的」使用者。要定義的 Scope，必須簡單地在 Eloquent 模型方法前面加上前綴 `scope`
 
 Scopes 總是會回傳一個查詢建構器的實例：
 
@@ -655,7 +654,7 @@ Scopes 總是會回傳一個查詢建構器的實例：
     class User extends Model
     {
         /**
-         * Scope 只查詢受歡迎的使用者。
+         * 只查詢受歡迎使用者的 Scope。
          *
          * @param \Illuminate\Database\Eloquent\Builder $query
          * @return \Illuminate\Database\Eloquent\Builder
@@ -666,7 +665,7 @@ Scopes 總是會回傳一個查詢建構器的實例：
         }
 
         /**
-         * Scopes 只查詢活躍的使用者。
+         * 只查詢活躍使用者的 Scope。
          *
          * @param \Illuminate\Database\Eloquent\Builder $query
          * @return \Illuminate\Database\Eloquent\Builder
@@ -683,9 +682,9 @@ Scope 一旦被定義，你可以在查詢模型時呼叫 scope 的方法。然�
 
     $users = App\User::popular()->active()->orderBy('created_at')->get();
 
-#### 動態 Scopes
+#### 動態 Scope
 
-有時你可能希望去定義一個接受參數的 Scope。只要開始新增額外參數到你的 Scope。Scope 參數應該在 `$query` 參數之後被定義：
+有時你可能希望去定義一個接受參數的 Scope。開始之前，只要新增額外參數到你的 Scope。Scope 參數應該在 `$query` 參數之後被定義：
 
     <?php
 
@@ -696,7 +695,7 @@ Scope 一旦被定義，你可以在查詢模型時呼叫 scope 的方法。然�
     class User extends Model
     {
         /**
-         * Scopes查詢只有引入給定類型的使用者。
+         * 查詢只有引入給定類型使用者的 Scope。
          *
          * @param \Illuminate\Database\Eloquent\Builder $query
          * @param mixed $type
@@ -719,7 +718,7 @@ Eloquent 模型可以讓你觸發下列模型的生命週期幾個時間點的�
 
 從資料庫中取得已存在的資料時，會觸發 `retrieved` 事件。當新的資料被第一次儲存時，會觸發 `creating` 和 `created` 事件。如果資料已經存在於資料庫，並呼叫 `save`，就會觸發 `updating` 和 `updated` 事件。然而，這兩種案例都會觸發 `saving` 和 `saved` 事件。
 
-請開始在你的 Eloquent 模型上定義 `$dispatchesEvents` 屬性，會映射 Eloquent 模型的生命週期的各個時間點到你的[事件類別](/docs/{{version}}/events):
+開始之前，在你的 Eloquent 模型上定義 `$dispatchesEvents` 屬性，它會映射 Eloquent 模型的生命週期到你的[事件類別](/docs/{{version}}/events):
 
     <?php
 
@@ -748,7 +747,7 @@ Eloquent 模型可以讓你觸發下列模型的生命週期幾個時間點的�
 <a name="observers"></a>
 ### Observer
 
-如果你在給定模型上監聽多個事件，你可以使用 Observer 來組織你的所有監聽器到單一個類別。Observer 類別有個方法名稱，會反映你想監聽的 Eloquent 事件。這些方法中的每一個都會接收模型作為它們的參數。Laravel 預設並不沒有 Observers 的目錄，不過你可以建立任何你想要的目錄來放置 Observer 類別：
+如果你在給定模型上監聽多個事件，你可以使用 Observer 來組織你的所有監聽器到單一個類別。Observer 類別有個方法名稱，會反射你想監聽的 Eloquent 事件。這些方法中的每一個都會接收模型作為它們的參數。Laravel 預設並沒有 Observer 的目錄，不過你可以建立任何你想要的目錄來放置 Observer 類別：
 
     <?php
 
@@ -781,7 +780,7 @@ Eloquent 模型可以讓你觸發下列模型的生命週期幾個時間點的�
         }
     }
 
-在模型上使用 `observe` 方法來註冊想要的 observer。你可以在一個服務提供者中使用 `boot` 方法來註冊 Observer。在這個範例中，我們會在 `AppServiceProvider` 中註冊 Observer：
+要註冊一個 observer，在你想觀察的模型上使用 observe 方法。你可以在一個服務提供者中使用 `boot` 方法來註冊 Observer。在這個範例中，我們會在 `AppServiceProvider` 中註冊 Observer：
 
     <?php
 

--- a/eloquent.md
+++ b/eloquent.md
@@ -1,53 +1,53 @@
-# Eloquent: Getting Started
+# Eloquent：入門
 
-- [Introduction](#introduction)
-- [Defining Models](#defining-models)
-    - [Eloquent Model Conventions](#eloquent-model-conventions)
-- [Retrieving Models](#retrieving-models)
-    - [Collections](#collections)
-    - [Chunking Results](#chunking-results)
-- [Retrieving Single Models / Aggregates](#retrieving-single-models)
-    - [Retrieving Aggregates](#retrieving-aggregates)
-- [Inserting & Updating Models](#inserting-and-updating-models)
-    - [Inserts](#inserts)
-    - [Updates](#updates)
-    - [Mass Assignment](#mass-assignment)
-    - [Other Creation Methods](#other-creation-methods)
-- [Deleting Models](#deleting-models)
-    - [Soft Deleting](#soft-deleting)
-    - [Querying Soft Deleted Models](#querying-soft-deleted-models)
-- [Query Scopes](#query-scopes)
-    - [Global Scopes](#global-scopes)
-    - [Local Scopes](#local-scopes)
-- [Events](#events)
-    - [Observers](#observers)
+- [介紹](#introduction)
+- [定義模型](#defining-models)
+    - [Eloquent 模型慣例](#eloquent-model-conventions)
+- [取得模型](#retrieving-models)
+    - [集合](#collections)
+    - [分塊結果](#chunking-results)
+- [取得單一模型或合計](#retrieving-single-models)
+    - [取得合計](#retrieving-aggregates)
+- [插入與更新模型](#inserting-and-updating-models)
+    - [插入](#inserts)
+    - [更新](#updates)
+    - [批量賦值](#mass-assignment)
+    - [其他建立方法](#other-creation-methods)
+- [刪除模型](#deleting-models)
+    - [軟刪除](#soft-deleting)
+    - [查詢被軟刪除的模型](#querying-soft-deleted-models)
+- [查詢 Scopes](#query-scopes)
+    - [全域的 Scopes](#global-scopes)
+    - [局部的 Scopes](#local-scopes)
+- [事件](#events)
+    - [Observer](#observers)
 
 <a name="introduction"></a>
-## Introduction
+## 介紹
 
-The Eloquent ORM included with Laravel provides a beautiful, simple ActiveRecord implementation for working with your database. Each database table has a corresponding "Model" which is used to interact with that table. Models allow you to query for data in your tables, as well as insert new records into the table.
+Laravel 的 Eloquent ORM 提供了漂亮、簡潔的 ActiveRecord 實作來和資料庫互動。每個資料庫表有一個對應的「模型」可以用來跟資料表互動。你可以透過模型查詢資料表內的資料，以及新增記錄到資料表中。
 
-Before getting started, be sure to configure a database connection in `config/database.php`. For more information on configuring your database, check out [the documentation](/docs/{{version}}/database#configuration).
+在開始之前，請確認有設定你的資料庫連結在 `config/database.php` 檔案內。更多資料庫的設定資訊，請查看[資料庫設定](/docs/{{version}}/database#configuration)。
 
 <a name="defining-models"></a>
-## Defining Models
+## 定義模型
 
-To get started, let's create an Eloquent model. Models typically live in the `app` directory, but you are free to place them anywhere that can be auto-loaded according to your `composer.json` file. All Eloquent models extend `Illuminate\Database\Eloquent\Model` class.
+開始之前，讓我們先建立一個 Eloquent 模型。模型通常放在 `app` 目錄，不過你可以自由地把他們放在任何可以透過你的 `composer.json` 自動載入的地方。所有的 Eloquent 模型都繼承 `Illuminate\Database\Eloquent\Model` 類別。
 
-The easiest way to create a model instance is using the `make:model` [Artisan command](/docs/{{version}}/artisan):
+建立模型實例的最簡單的方法是使用 [Artisan 指令](/docs/{{version}}/artisan) 的 `make:model`：
 
     php artisan make:model User
 
-If you would like to generate a [database migration](/docs/{{version}}/migrations) when you generate the model, you may use the `--migration` or `-m` option:
+假設當你生成一個模型時，想要產生一個[資料庫遷移](/docs/{{version}}/schema#database-migrations)，可以使用 `--migration` 或 `-m` 選項：
 
     php artisan make:model User --migration
 
     php artisan make:model User -m
 
 <a name="eloquent-model-conventions"></a>
-### Eloquent Model Conventions
+### Eloquent 模型慣例
 
-Now, let's look at an example `Flight` model, which we will use to retrieve and store information from our `flights` database table:
+現在，讓我們來看一個 `Flight` 模型的範例，我們將會用它來從 `flights` 資料表取回與儲存資訊：
 
     <?php
 
@@ -60,10 +60,9 @@ Now, let's look at an example `Flight` model, which we will use to retrieve and 
         //
     }
 
+#### 資料表名字
 
-#### Table Names
-
-Note that we did not tell Eloquent which table to use for our `Flight` model. By convention, the "snake case", plural name of the class will be used as the table name unless another name is explicitly specified. So, in this case, Eloquent will assume the `Flight` model stores records in the `flights` table. You may specify a custom table by defining a `table` property on your model:
+請注意，我們並沒有告訴 Eloquent `Flight` 模型該使用哪一個資料表。依照慣例，除非明確地指定其他名稱，不然類別的小寫、底線、複數形式會拿來當作資料表的表單名稱。所以，這個案例中，Eloquent 將會假設 `Flight` 模型儲存記錄在 `flights` 資料表。你可以在模型上定義一個 `table` 屬性，用來指定自訂的資料表：
 
     <?php
 
@@ -74,22 +73,22 @@ Note that we did not tell Eloquent which table to use for our `Flight` model. By
     class Flight extends Model
     {
         /**
-         * The table associated with the model.
+         * 與模型關聯的資料表。
          *
          * @var string
          */
         protected $table = 'my_flights';
     }
 
-#### Primary Keys
+#### 主鍵
 
-Eloquent will also assume that each table has a primary key column named `id`. You may define a protected `$primaryKey` property to override this convention.
+Eloquent 也會假設每個資料表有一個主鍵欄位叫做 `id`。你可以定義一個 `$primaryKey` 屬性來覆寫這個慣例。
 
-In addition, Eloquent assumes that the primary key is an incrementing integer value, which means that by default the primary key will be cast to an `int` automatically. If you wish to use a non-incrementing or a non-numeric primary key you must set the public `$incrementing` property on your model to `false`. If your primary key is not an integer, you should set the protected `$keyType` property on your model to `string`.
+此外，Eloquent 會假設主鍵是一個遞增的整數值，這表示預設的主鍵位自動轉換成 `int`。如果你希望使用非遞增或非數字的主鍵，務必把模型上的 `public $incrementing` 屬性設定為 `false`。如果你的主鍵不是一個整數，你應該將模型上的 `protected $keyType` 屬性設定為 `string`。
 
-#### Timestamps
+#### 時間戳
 
-By default, Eloquent expects `created_at` and `updated_at` columns to exist on your tables.  If you do not wish to have these columns automatically managed by Eloquent, set the `$timestamps` property on your model to `false`:
+預設的 Eloquent 會預期你的資料表會有 `created_at` 和 `updated_at` 欄位。如果你不希望 Eloquent 自動管理這些欄位，請將模型上的 `$timestamps` 屬性設定為 `false`：
 
     <?php
 
@@ -100,14 +99,14 @@ By default, Eloquent expects `created_at` and `updated_at` columns to exist on y
     class Flight extends Model
     {
         /**
-         * Indicates if the model should be timestamped.
+         * 表示模型使否應該被戳記時間。
          *
          * @var bool
          */
         public $timestamps = false;
     }
 
-If you need to customize the format of your timestamps, set the `$dateFormat` property on your model. This property determines how date attributes are stored in the database, as well as their format when the model is serialized to an array or JSON:
+如果你需要客製化你的時間戳記格式，在你的模型內設定 `$dateFormat` 屬性。這個屬性決定日期如何在資料庫中儲存，以及當模型被序列化成陣列或是 JSON 時的格式：
 
     <?php
 
@@ -118,14 +117,14 @@ If you need to customize the format of your timestamps, set the `$dateFormat` pr
     class Flight extends Model
     {
         /**
-         * The storage format of the model's date columns.
+         * 模型的日期欄位儲存格式。
          *
          * @var string
          */
         protected $dateFormat = 'U';
     }
 
-If you need to customize the names of the columns used to store the timestamps, you may set the `CREATED_AT` and `UPDATED_AT` constants in your model:
+如果你需要自訂欄位名稱，並用來儲存時間戳，你可以在模型中設定 `CREATED_AT` 和 `UPDATED_AT` 常數：
 
     <?php
 
@@ -135,9 +134,9 @@ If you need to customize the names of the columns used to store the timestamps, 
         const UPDATED_AT = 'last_update';
     }
 
-#### Database Connection
+#### 資料庫連線
 
-By default, all Eloquent models will use the default database connection configured for your application. If you would like to specify a different connection for the model, use the `$connection` property:
+預設所有 Eloquent 模型會使用應用程式預設的資料庫連線設定。如果你想為模型指定不同的連線，請使用 `$connection` 屬性：
 
     <?php
 
@@ -148,7 +147,7 @@ By default, all Eloquent models will use the default database connection configu
     class Flight extends Model
     {
         /**
-         * The connection name for the model.
+         * 為模型選擇連線名稱。
          *
          * @var string
          */
@@ -156,9 +155,9 @@ By default, all Eloquent models will use the default database connection configu
     }
 
 <a name="retrieving-models"></a>
-## Retrieving Models
+## 取得模型
 
-Once you have created a model and [its associated database table](/docs/{{version}}/migrations#writing-migrations), you are ready to start retrieving data from your database. Think of each Eloquent model as a powerful [query builder](/docs/{{version}}/queries) allowing you to fluently query the database table associated with the model. For example:
+一旦你建立了一個模型並且將模型[關聯到資料表](/docs/{{version}}/schema)，你就可以從資料庫中取得資料。把每個 Eloquent 模型想像成強大的[查詢建構器](/docs/{{version}}/queries)，讓你可以流暢地查詢與模型關聯的資料表。例如：
 
     <?php
 
@@ -170,36 +169,36 @@ Once you have created a model and [its associated database table](/docs/{{versio
         echo $flight->name;
     }
 
-#### Adding Additional Constraints
+#### 新增額外的限制
 
-The Eloquent `all` method will return all of the results in the model's table. Since each Eloquent model serves as a [query builder](/docs/{{version}}/queries), you may also add constraints to queries, and then use the `get` method to retrieve the results:
+Eloquent 的 `all` 方法會回傳在模型資料表中所有的結果。由於每個 Eloquent 模型可以當作一個[查詢建構器](/docs/{{version}}/queries)，所以你可以在查詢中增加規則，然後透過 `get` 方法來取得結果：
 
     $flights = App\Flight::where('active', 1)
                    ->orderBy('name', 'desc')
                    ->take(10)
                    ->get();
 
-> {tip} Since Eloquent models are query builders, you should review all of the methods available on the [query builder](/docs/{{version}}/queries). You may use any of these methods in your Eloquent queries.
+> {tip} 由於 Eloquent 模型是查詢建構器，應該檢閱所有[查詢建構器](/docs/{{version}}/queries)可用的方法。你可以在你的 Eloquent 查詢中使用這其中的任何方法。
 
 <a name="collections"></a>
-### Collections
+### 集合
 
-For Eloquent methods like `all` and `get` which retrieve multiple results, an instance of `Illuminate\Database\Eloquent\Collection` will be returned. The `Collection` class provides [a variety of helpful methods](/docs/{{version}}/eloquent-collections#available-methods) for working with your Eloquent results:
+像是 `all` 和 `get` 能夠取得多個結果的 Eloquent 方法，會回傳 `Illuminate\Database\Eloquent\Collection` 實例。`Collection` 類別為處理你的 Eloquent 結果提供[各種有用的方法](/docs/{{version}}/eloquent-collections#available-methods)：
 
     $flights = $flights->reject(function ($flight) {
         return $flight->cancelled;
     });
 
-Of course, you may also simply loop over the collection like an array:
+當然，你也可以只對集合執行迴圈，像是疊代陣列：
 
     foreach ($flights as $flight) {
         echo $flight->name;
     }
 
 <a name="chunking-results"></a>
-### Chunking Results
+### 分塊結果
 
-If you need to process thousands of Eloquent records, use the `chunk` command. The `chunk` method will retrieve a "chunk" of Eloquent models, feeding them to a given `Closure` for processing. Using the `chunk` method will conserve memory when working with large result sets:
+如果你需要處理上千筆 Eloquent 查詢結果，可以使用 `chunk` 命令。`chunk` 方法將會取得一個 Eloquent 模型的「分塊」，將它們送到給定的 `閉包 (Closure)` 進行處理。當你在處理大量的結果時，使用 `chunk` 方法可以節省記憶體：
 
     Flight::chunk(200, function ($flights) {
         foreach ($flights as $flight) {
@@ -207,61 +206,61 @@ If you need to process thousands of Eloquent records, use the `chunk` command. T
         }
     });
 
-The first argument passed to the method is the number of records you wish to receive per "chunk". The Closure passed as the second argument will be called for each chunk that is retrieved from the database. A database query will be executed to retrieve each chunk of records passed to the Closure.
+傳遞到方法的第一個參數是表示你希望每次「分塊」要接收的資料數量。閉包則作為第二個參數傳遞，它將會在每次從資料取出分塊時被呼叫。資料庫查詢會將執行接收到的每個記錄塊傳入閉包中。
 
-#### Using Cursors
+#### 使用指標
 
-The `cursor` method allows you to iterate through your database records using a cursor, which will only execute a single query. When processing large amounts of data, the `cursor` method may be used to greatly reduce your memory usage:
+`cursor` 方法可以讓你使用指標來搜索資料庫記錄，並只會執行一次查詢。在處理大量資料時，使用 `cursor` 方法可以大幅減少記憶體的使用量：
 
     foreach (Flight::where('foo', 'bar')->cursor() as $flight) {
         //
     }
 
 <a name="retrieving-single-models"></a>
-## Retrieving Single Models / Aggregates
+## 取得單一模型或合計
 
-Of course, in addition to retrieving all of the records for a given table, you may also retrieve single records using `find` or `first`. Instead of returning a collection of models, these methods return a single model instance:
+當然，除了取得給定資料表的所有記錄，你還可以使用 `find` 或 `first` 來取得單一記錄。這些方法會回傳單一模型實例，而非回傳模型的集合：
 
-    // Retrieve a model by its primary key...
+    // 透過主鍵取得模型...
     $flight = App\Flight::find(1);
 
-    // Retrieve the first model matching the query constraints...
+    // 取得符合查詢條件的第一個模型...
     $flight = App\Flight::where('active', 1)->first();
 
-You may also call the `find` method with an array of primary keys, which will return a collection of the matching records:
+你也可以使用主鍵陣列作為參數來呼叫 `find` 方法，這會回傳符合記錄的集合：
 
     $flights = App\Flight::find([1, 2, 3]);
 
-#### Not Found Exceptions
+#### 因找不到而拋出的例外
 
-Sometimes you may wish to throw an exception if a model is not found. This is particularly useful in routes or controllers. The `findOrFail` and `firstOrFail` methods will retrieve the first result of the query; however, if no result is found, a `Illuminate\Database\Eloquent\ModelNotFoundException` will be thrown:
+有時你可能希望因為找不到模型而拋出例外。這在路由或控制器特別好用。`findOrFail` 和 `firstOrFail` 方法會取得查詢的第一個結果。然而，如果未能找到結果，`Illuminate\Database\Eloquent\ModelNotFoundException` 會拋出例外：
 
     $model = App\Flight::findOrFail(1);
 
     $model = App\Flight::where('legs', '>', 100)->firstOrFail();
 
-If the exception is not caught, a `404` HTTP response is automatically sent back to the user. It is not necessary to write explicit checks to return `404` responses when using these methods:
+如果沒抓到例外，則會自動發送 `404` HTTP 會應給使用者。在使用這些方法時，不必仔細撰寫檢查要回傳的 `404` 回應：
 
     Route::get('/api/flights/{id}', function ($id) {
         return App\Flight::findOrFail($id);
     });
 
 <a name="retrieving-aggregates"></a>
-### Retrieving Aggregates
+### 取得合計
 
-You may also use the `count`, `sum`, `max`, and other [aggregate methods](/docs/{{version}}/queries#aggregates) provided by the [query builder](/docs/{{version}}/queries). These methods return the appropriate scalar value instead of a full model instance:
+你也可以使用[查詢建構器](/docs/{{version}}/queries)提供的 `count`、`sum`、`max` 和其他[合計方法](/docs/{{version}}/queries#aggregates)。這些方法會回傳適當的純量值，而不是完整的模型實例：
 
     $count = App\Flight::where('active', 1)->count();
 
     $max = App\Flight::where('active', 1)->max('price');
 
 <a name="inserting-and-updating-models"></a>
-## Inserting & Updating Models
+## 插入與更新模型
 
 <a name="inserts"></a>
-### Inserts
+### 插入
 
-To create a new record in the database, simply create a new model instance, set attributes on the model, then call the `save` method:
+要在資料庫建立一筆新紀錄，只要建立一個新模型實例，並在模型上設定屬性，接著呼叫 `save` 方法：
 
     <?php
 
@@ -274,14 +273,14 @@ To create a new record in the database, simply create a new model instance, set 
     class FlightController extends Controller
     {
         /**
-         * Create a new flight instance.
+         * 建立新 flight 實例。
          *
          * @param  Request  $request
          * @return Response
          */
         public function store(Request $request)
         {
-            // Validate the request...
+            // 驗證請求...
 
             $flight = new Flight;
 
@@ -291,12 +290,12 @@ To create a new record in the database, simply create a new model instance, set 
         }
     }
 
-In this example, we simply assign the `name` parameter from the incoming HTTP request to the `name` attribute of the `App\Flight` model instance. When we call the `save` method, a record will be inserted into the database. The `created_at` and `updated_at` timestamps will automatically be set when the `save` method is called, so there is no need to set them manually.
+在這個範例中，我們把進來的 HTTP 請求的 `name` 參數簡單地指定給 `App\Flight` 模型實例的 `name` 屬性。當我們呼叫 `save` 方法，就會新增一筆記錄到資料庫中。當 `save` 方法被呼叫時，`created_at` 以及 `updated_at` 時間戳記將會自動被設定，所以不需要手動去設定它們。
 
 <a name="updates"></a>
-### Updates
+### 更新
 
-The `save` method may also be used to update models that already exist in the database. To update a model, you should retrieve it, set any attributes you wish to update, and then call the `save` method. Again, the `updated_at` timestamp will automatically be updated, so there is no need to manually set its value:
+`save` 方法也可以用於更新資料庫中已經存在的模型。要更新模型，你必須先取回模型，設定任何你希望更新的屬性，接著呼叫 `save` 方法。同樣的，`updated_at` 時間戳記將會自動被更新，所以不需要手動設定它的值：
 
     $flight = App\Flight::find(1);
 
@@ -304,26 +303,27 @@ The `save` method may also be used to update models that already exist in the da
 
     $flight->save();
 
-#### Mass Updates
+#### 批量更新
 
-Updates can also be performed against any number of models that match a given query. In this example, all flights that are `active` and have a `destination` of `San Diego` will be marked as delayed:
+也可以針對符合給定查詢的任意數量模型執行更新。在這個範例中，所有 `active` 並且 `destination` 為 `San Diego` 的航班，將會被標記為延遲：
 
     App\Flight::where('active', 1)
               ->where('destination', 'San Diego')
               ->update(['delayed' => 1]);
 
-The `update` method expects an array of column and value pairs representing the columns that should be updated.
+`update` 方法預期收到一個欄位與值成對的陣列，來代表應該被更新的欄位。
 
-> {note} When issuing a mass update via Eloquent, the `saved` and `updated` model events will not be fired for the updated models. This is because the models are never actually retrieved when issuing a mass update.
+> {note} 透過 Eloquent 來批量更新時，更新後的模型將不觸發 `saved` 和 `updated` 模型事件。這是因為發出批量更新時，實際上並不會取得模型。
 
 <a name="mass-assignment"></a>
-### Mass Assignment
+### 批量賦值
 
-You may also use the `create` method to save a new model in a single line. The inserted model instance will be returned to you from the method. However, before doing so, you will need to specify either a `fillable` or `guarded` attribute on the model, as all Eloquent models protect against mass-assignment by default.
+你也可以在同一行上使用 `create` 方法來儲存新模型。被插入的模型實例會從該方法回傳給你。然而在這之前，你會需要在模型上指定 `fillable` 或 `guarded` 這兩種屬性選擇一種，因為所有的 Eloquent 模型預設會針對批量賦值作保護。
 
-A mass-assignment vulnerability occurs when a user passes an unexpected HTTP parameter through a request, and that parameter changes a column in your database you did not expect. For example, a malicious user might send an `is_admin` parameter through an HTTP request, which is then passed into your model's `create` method, allowing the user to escalate themselves to an administrator.
+當使用者傳入的請求有你沒料想到的 HTTP 參數，並且該參數會非預期竄改資料庫中的欄位，會發生批量賦值的漏洞。例如，一個惡意的使用者硬是要發送包含 `is_admin` 參數的 HTTP 請求，然後映射到你模型的 `create` 方法，藉此同意使用者升級到管理者權限。
 
-So, to get started, you should define which model attributes you want to make mass assignable. You may do this using the `$fillable` property on the model. For example, let's make the `name` attribute of our `Flight` model mass assignable:
+所以，你應該開始定義想要被批量賦值的模型屬性。你可以在模型上使用 `$fillable` 屬性來達到這點。例如讓我們實際去做 `Flight` 模型的 `name`
+屬性的批量賦值：
 
     <?php
 
@@ -334,24 +334,24 @@ So, to get started, you should define which model attributes you want to make ma
     class Flight extends Model
     {
         /**
-         * The attributes that are mass assignable.
+         * 可被批量賦值的屬性。
          *
          * @var array
          */
         protected $fillable = ['name'];
     }
 
-Once we have made the attributes mass assignable, we can use the `create` method to insert a new record in the database. The `create` method returns the saved model instance:
+一旦我們已經設定屬性為可以被批量賦值的，我們可以使用 `create` 方法來新增一筆新記錄到資料庫。`create` 方法回傳已經被儲存的模型實例：
 
     $flight = App\Flight::create(['name' => 'Flight 10']);
 
-If you already have a model instance, you may use the `fill` method to populate it with an array of attributes:
+如果你已經有一個模型實例，你可以使用 `fill` 方法來填充屬性陣列：
 
     $flight->fill(['name' => 'Flight 22']);
 
-#### Guarding Attributes
+#### 屬性的白名單
 
-While `$fillable` serves as a "white list" of attributes that should be mass assignable, you may also choose to use `$guarded`. The `$guarded` property should contain an array of attributes that you do not want to be mass assignable. All other attributes not in the array will be mass assignable. So, `$guarded` functions like a "black list". Of course, you should use either `$fillable` or `$guarded` - not both. In the example below, all attributes **except for `price`** will be mass assignable:
+`$fillable` 作為一個可以被批量賦值的屬性的「白名單」，然而你也可以選擇使用 `$guarded`。`$guarded` 屬性應該包含一個屬性的陣列，是你不想要被批量賦值的。所有不在陣列裡面的其他屬性將會是可以被批量賦值的。所以，`$guarded` 的功能像是一個「黑名單」。當然，你應該使用 `$fillable` 或 `$guarded` - 而不是兩者。在下列範例中，**除了 `price`** 的所有屬性都可被批量賦值：
 
     <?php
 
@@ -362,70 +362,70 @@ While `$fillable` serves as a "white list" of attributes that should be mass ass
     class Flight extends Model
     {
         /**
-         * The attributes that aren't mass assignable.
+         * 不可被批量賦值的屬性。
          *
          * @var array
          */
         protected $guarded = ['price'];
     }
 
-If you would like to make all attributes mass assignable, you may define the `$guarded` property as an empty array:
+如果你想要所有屬性都能被批量賦值，你可以定義 `$guarded` 屬性為空陣列：
 
     /**
-     * The attributes that aren't mass assignable.
+     * 不可被批量賦值的屬性。
      *
      * @var array
      */
     protected $guarded = [];
 
 <a name="other-creation-methods"></a>
-### Other Creation Methods
+### 其他建立方法
 
-#### `firstOrCreate`/ `firstOrNew`
+#### `firstOrCreate` 和 `firstOrNew`
 
-There are two other methods you may use to create models by mass assigning attributes: `firstOrCreate` and `firstOrNew`. The `firstOrCreate` method will attempt to locate a database record using the given column / value pairs. If the model can not be found in the database, a record will be inserted with the given attributes.
+你可以透過批量賦值屬性到另外兩種方法來建立模型：`firstOrCreate` 和 `firstOrNew`。`firstOrCreate` 方法會嘗試使用給定的欄位與值來找資料庫記錄。如果在資料庫中無法找到該模型，會從屬性的第一個參數以及那些可選的參數第二個參數中插入一筆記錄。
 
-The `firstOrNew` method, like `firstOrCreate` will attempt to locate a record in the database matching the given attributes. However, if a model is not found, a new model instance will be returned. Note that the model returned by `firstOrNew` has not yet been persisted to the database. You will need to call `save` manually to persist it:
+`firstOrNew` 方法類似 `firstOrCreate`，會嘗試在資料庫查詢符合給定屬性的記錄。然而，如果沒找到模型，將會回傳一個新模型。該注意 `firstOrNew` 回傳的模型還未存到資料庫，你還需要手動呼叫 `save` 來儲存它：
 
-    // Retrieve flight by name, or create it if it doesn't exist...
+    // 依名稱取得航班，或因為不存在而建立它...
     $flight = App\Flight::firstOrCreate(['name' => 'Flight 10']);
 
-    // Retrieve flight by name, or create it with the name and delayed attributes...
+    // 依名稱取得航班，或建立該名稱與延遲的屬性...
     $flight = App\Flight::firstOrCreate(
         ['name' => 'Flight 10'], ['delayed' => 1]
     );
 
-    // Retrieve by name, or instantiate...
+    // 依名稱取得航班，或實例...
     $flight = App\Flight::firstOrNew(['name' => 'Flight 10']);
 
-    // Retrieve by name, or instantiate with the name and delayed attributes...
+    // 依名稱取得航班，或實例的名稱和延遲的屬性...
     $flight = App\Flight::firstOrNew(
         ['name' => 'Flight 10'], ['delayed' => 1]
     );
 
 #### `updateOrCreate`
 
-You may also come across situations where you want to update an existing model or create a new model if none exists. Laravel provides an `updateOrCreate` method to do this in one step. Like the `firstOrCreate` method, `updateOrCreate` persists the model, so there's no need to call `save()`:
+你還可能遇到想要去更新已存在的模型或者如果模型不存在去新增的情況。Laravel 提供 `updateOrCreate` 方法，只需要一步即可做到。`updateOrCreate` 類似 `firstOrCreate` 方法儲存模型，所以這裡不需要呼叫 `save()`：
 
-    // If there's a flight from Oakland to San Diego, set the price to $99.
-    // If no matching model exists, create one.
+    // 如果是從奧克蘭到聖地牙哥的航班，將價格訂為 99 美金。
+    // 如果沒有符合的模型，就建立一個。
     $flight = App\Flight::updateOrCreate(
         ['departure' => 'Oakland', 'destination' => 'San Diego'],
         ['price' => 99]
     );
 
 <a name="deleting-models"></a>
-## Deleting Models
+## 刪除模型
 
-To delete a model, call the `delete` method on a model instance:
+在模型實例上呼叫 `delete` 方法來刪除一個模型：
 
     $flight = App\Flight::find(1);
 
     $flight->delete();
 
-#### Deleting An Existing Model By Key
+#### 依鍵號刪除已存在的模型
 
-In the example above, we are retrieving the model from the database before calling the `delete` method. However, if you know the primary key of the model, you may delete the model without retrieving it. To do so, call the `destroy` method:
+在上述範例中，我們會在呼叫 `delete` 方法前，從資料庫取得模型。然而，如果你知道該模型的主鍵，你可以沒有取得模型就刪除它。呼叫 `destroy` 方法來達成：
 
     App\Flight::destroy(1);
 
@@ -433,18 +433,18 @@ In the example above, we are retrieving the model from the database before calli
 
     App\Flight::destroy(1, 2, 3);
 
-#### Deleting Models By Query
+#### 依查詢來刪除模型
 
-Of course, you may also run a delete statement on a set of models. In this example, we will delete all flights that are marked as inactive. Like mass updates, mass deletes will not fire any model events for the models that are deleted:
+當然，你也可以在一組模型上執行刪除的語法。在這個範例中，我們會刪除所有被標記無效的航班。批量刪除類似批量更新，不會觸發刪除模型的任何模型事件：
 
     $deletedRows = App\Flight::where('active', 0)->delete();
 
-> {note} When executing a mass delete statement via Eloquent, the `deleting` and `deleted` model events will not be fired for the deleted models. This is because the models are never actually retrieved when executing the delete statement.
+> {note} 透過 Eloquent 執行批量刪除語法，`deleting` 和 `deleted` 模型不會觸發刪除模型的事件。這是因為在執行刪除語法時，並未實際取得模型。
 
 <a name="soft-deleting"></a>
-### Soft Deleting
+### 軟刪除
 
-In addition to actually removing records from your database, Eloquent can also "soft delete" models. When models are soft deleted, they are not actually removed from your database. Instead, a `deleted_at` attribute is set on the model and inserted into the database. If a model has a non-null `deleted_at` value, the model has been soft deleted. To enable soft deletes for a model, use the `Illuminate\Database\Eloquent\SoftDeletes` trait on the model and add the `deleted_at` column to your `$dates` property:
+除了從資料庫確實的移除記錄，Eloquent 也能「軟刪除」模型。當模型被軟刪除時，它們不會真的從你的資料庫中移除，`deleted_at` 屬性是在模型上設定並寫入到資料庫。如果模型有不能是 null 的 `deleted_at` 值，該模型將會被軟刪除。要為模型啟用軟刪除，請在模型上使用 `Illuminate\Database\Eloquent\SoftDeletes` trait 並新增 `deleted_at` 欄位到你的 `$dates` 屬性：
 
     <?php
 
@@ -458,87 +458,87 @@ In addition to actually removing records from your database, Eloquent can also "
         use SoftDeletes;
 
         /**
-         * The attributes that should be mutated to dates.
+         * 該屬性會變更為日期。
          *
          * @var array
          */
         protected $dates = ['deleted_at'];
     }
 
-Of course, you should add the `deleted_at` column to your database table. The Laravel [schema builder](/docs/{{version}}/migrations) contains a helper method to create this column:
+當然，你應該新增 `deleted_at` 欄位到你的資料表。Laravel [schema 建構器](/docs/{{version}}/migrations)具有一個輔助函式來建立這個欄位：
 
     Schema::table('flights', function ($table) {
         $table->softDeletes();
     });
 
-Now, when you call the `delete` method on the model, the `deleted_at` column will be set to the current date and time. And, when querying a model that uses soft deletes, the soft deleted models will automatically be excluded from all query results.
+現在，當你在模型上呼叫 `delete` 方法時，`deleted_at` 欄位會設定當前日期與時間。還有，查詢有使用軟刪除的模型時，被軟刪除的模型會自動從所有查詢結果中排除。
 
-To determine if a given model instance has been soft deleted, use the `trashed` method:
+若要確定給定的模型實例是否被軟刪除，請使用 `trashed` 方法：
 
     if ($flight->trashed()) {
         //
     }
 
 <a name="querying-soft-deleted-models"></a>
-### Querying Soft Deleted Models
+### 查詢被軟刪除的模型
 
-#### Including Soft Deleted Models
+#### 包含被軟刪除的模型
 
-As noted above, soft deleted models will automatically be excluded from query results. However, you may force soft deleted models to appear in a result set using the `withTrashed` method on the query:
+如上所述，被軟刪除的模型會自動從查詢結果中排除。然而，你可以在查詢上使用 `withTrashed` 方法，強制被軟刪除的模型出現在結果中：
 
     $flights = App\Flight::withTrashed()
                     ->where('account_id', 1)
                     ->get();
 
-The `withTrashed` method may also be used on a [relationship](/docs/{{version}}/eloquent-relationships) query:
+`withTrashed` 方法也可以被用在 [Eloquent 的關聯](/docs/{{version}}/eloquent-relationships)查詢上：
 
     $flight->history()->withTrashed()->get();
 
-#### Retrieving Only Soft Deleted Models
+#### 只取得被軟刪除的模型
 
-The `onlyTrashed` method will retrieve **only** soft deleted models:
+`onlyTrashed` 方法會**只有**取得被軟刪除的模型：
 
     $flights = App\Flight::onlyTrashed()
                     ->where('airline_id', 1)
                     ->get();
 
-#### Restoring Soft Deleted Models
+#### 取得被軟刪除的模型
 
-Sometimes you may wish to "un-delete" a soft deleted model. To restore a soft deleted model into an active state, use the `restore` method on a model instance:
+有時你可能希望「取消刪除」被軟刪除的模型。要把被軟刪除的資料恢復到一般狀態，請在模型實例上使用 `restore` 方法：
 
     $flight->restore();
 
-You may also use the `restore` method in a query to quickly restore multiple models. Again, like other "mass" operations, this will not fire any model events for the models that are restored:
+你也可以在查詢中使用 `restore` 方法來快速恢復多筆資料。就像其他「批量」操作，這不會在恢復資料的時候觸發任何模型實踐：
 
     App\Flight::withTrashed()
             ->where('airline_id', 1)
             ->restore();
 
-Like the `withTrashed` method, the `restore` method may also be used on [relationships](/docs/{{version}}/eloquent-relationships):
+像是 `withTrashed` 方法，`restore` 方法也可被用在 [Eloquent 關聯](/docs/{{version}}/eloquent-relationships)上：
 
     $flight->history()->restore();
 
-#### Permanently Deleting Models
+#### 永久刪除模型
 
-Sometimes you may need to truly remove a model from your database. To permanently remove a soft deleted model from the database, use the `forceDelete` method:
+有時你可能需要真的從資料庫中刪除一筆資料。使用 `forceDelete` 方法可以從資料庫中永久移除一筆被軟刪除的資料：
 
-    // Force deleting a single model instance...
+    // 強制刪除單一個模型實例...
     $flight->forceDelete();
 
-    // Force deleting all related models...
+    // 強制刪除所有關聯模型...
     $flight->history()->forceDelete();
 
 <a name="query-scopes"></a>
-## Query Scopes
+## 查詢 Scopes
 
 <a name="global-scopes"></a>
-### Global Scopes
+### 全域的 Scopes
 
-Global scopes allow you to add constraints to all queries for a given model. Laravel's own [soft delete](#soft-deleting) functionality utilizes global scopes to only pull "non-deleted" models from the database. Writing your own global scopes can provide a convenient, easy way to make sure every query for a given model receives certain constraints.
+全域的 Scopes 可以讓你為給定模型新增條件到所有查詢。Laravel 自己的[軟刪除](#soft-deleting) 功能利用全域的 Scopes 能從資料庫中只取出「未刪除」模型。撰寫自己全域的 Scopes 能提供更方便且簡單的方式來確保給定模型的每個查詢都能受到一定的限制。
 
-#### Writing Global Scopes
+#### 撰寫全域的 Scopes
 
-Writing a global scope is simple. Define a class that implements the `Illuminate\Database\Eloquent\Scope` interface. This interface requires you to implement one method: `apply`. The `apply` method may add `where` constraints to the query as needed:
+撰寫全域的 scope 是相當簡單的事情。定義實作 `Illuminate\Database\Eloquent\Scope` 介面的類別。這個介面會要求你實作 `apply` 方法，`apply` 方法可以根據需要來新增 `where` 來查詢：
 
     <?php
 
@@ -551,7 +551,7 @@ Writing a global scope is simple. Define a class that implements the `Illuminate
     class AgeScope implements Scope
     {
         /**
-         * Apply the scope to a given Eloquent query builder.
+         * 將 Scope 應用於給定的 Eloquent 查詢建構器。
          *
          * @param  \Illuminate\Database\Eloquent\Builder  $builder
          * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -563,11 +563,11 @@ Writing a global scope is simple. Define a class that implements the `Illuminate
         }
     }
 
-> {tip} If your global scope is adding columns to the select clause of the query, you should use the `addSelect` method instead of `select`. This will prevent the unintentional replacement of the query's existing select clause.
+> {tip} 如果你的全域的 Scope 正在新增欄位到查詢的 select 子句，你應該使用 `addSelect` 方法，而非 `select`。這可避免不小心換掉現有的查詢 select 子句。
 
-#### Applying Global Scopes
+#### 應用在全域的 Scopes
 
-To assign a global scope to a model, you should override a given model's `boot` method and use the `addGlobalScope` method:
+要指派全域的 Scope 到模型，你應該覆寫給定模型的 `boot` 方法並使用 `addGlobalScope` 方法：
 
     <?php
 
@@ -579,7 +579,7 @@ To assign a global scope to a model, you should override a given model's `boot` 
     class User extends Model
     {
         /**
-         * The "booting" method of the model.
+         * 該模型的「啟動」方法。
          *
          * @return void
          */
@@ -591,13 +591,13 @@ To assign a global scope to a model, you should override a given model's `boot` 
         }
     }
 
-After adding the scope, a query to `User::all()` will produce the following SQL:
+新增了 Scope 之後，`User::all()` 查詢會產生以下的 SQL：
 
     select * from `users` where `age` > 200
 
-#### Anonymous Global Scopes
+#### 匿名全域的 Scopes
 
-Eloquent also allows you to define global scopes using Closures, which is particularly useful for simple scopes that do not warrant a separate class:
+Eloquent 也可以讓你使用閉包來定義全域的，這在簡單的作用域內相當的有用，但是不保證在獨立的類別內：
 
     <?php
 
@@ -609,7 +609,7 @@ Eloquent also allows you to define global scopes using Closures, which is partic
     class User extends Model
     {
         /**
-         * The "booting" method of the model.
+         * 該模型的「啟動」方法。
          *
          * @return void
          */
@@ -623,28 +623,28 @@ Eloquent also allows you to define global scopes using Closures, which is partic
         }
     }
 
-#### Removing Global Scopes
+#### 移除全域的 Scopes
 
-If you would like to remove a global scope for a given query, you may use the `withoutGlobalScope` method. The method accepts the class name of the global scope as its only argument:
+如果你想要為給定的查詢移除全域的 Scope，你可以使用 `withoutGlobalScope` 方法。該方法接受全域的 Scope 的類別名稱作為唯一參數：
 
     User::withoutGlobalScope(AgeScope::class)->get();
 
-If you would like to remove several or even all of the global scopes, you may use the `withoutGlobalScopes` method:
+如果你想要移除幾個或甚至所有的全域的 Scopes，你可以使用 `withoutGlobalScopes` 方法：
 
-    // Remove all of the global scopes...
+    // 移除所有的全域的 Scopes...
     User::withoutGlobalScopes()->get();
 
-    // Remove some of the global scopes...
+    // 移除某些全域的 Scopes...
     User::withoutGlobalScopes([
         FirstScope::class, SecondScope::class
     ])->get();
 
 <a name="local-scopes"></a>
-### Local Scopes
+### 局部的 Scopes
 
-Local scopes allow you to define common sets of constraints that you may easily re-use throughout your application. For example, you may need to frequently retrieve all users that are considered "popular". To define a scope, simply prefix an Eloquent model method with `scope`.
+局部的 Scopes 讓你定義限制的共用集合，它可以輕鬆地在你的應用程式重複使用。例如，你可能需要頻繁地取得所有被認為是「受歡迎的」使用者。要定義的 Scopes，必須簡單地在 Eloquent 模型方法前面加上前綴 `scope`
 
-Scopes should always return a query builder instance:
+Scopes 總是會回傳一個查詢建構器的實例：
 
     <?php
 
@@ -655,7 +655,7 @@ Scopes should always return a query builder instance:
     class User extends Model
     {
         /**
-         * Scope a query to only include popular users.
+         * Scope 只查詢受歡迎的使用者。
          *
          * @param \Illuminate\Database\Eloquent\Builder $query
          * @return \Illuminate\Database\Eloquent\Builder
@@ -666,7 +666,7 @@ Scopes should always return a query builder instance:
         }
 
         /**
-         * Scope a query to only include active users.
+         * Scopes 只查詢活躍的使用者。
          *
          * @param \Illuminate\Database\Eloquent\Builder $query
          * @return \Illuminate\Database\Eloquent\Builder
@@ -677,15 +677,15 @@ Scopes should always return a query builder instance:
         }
     }
 
-#### Utilizing A Local Scope
+#### 利用局部的 Scope
 
-Once the scope has been defined, you may call the scope methods when querying the model. However, you do not need to include the `scope` prefix when calling the method. You can even chain calls to various scopes, for example:
+Scope 一旦被定義，你可以在查詢模型時呼叫 scope 的方法。然而，你並不需要在呼叫該方法時引入 `scope` 前綴。你甚至能鏈結呼叫各種 Scope，例如：
 
     $users = App\User::popular()->active()->orderBy('created_at')->get();
 
-#### Dynamic Scopes
+#### 動態 Scopes
 
-Sometimes you may wish to define a scope that accepts parameters. To get started, just add your additional parameters to your scope. Scope parameters should be defined after the `$query` parameter:
+有時你可能希望去定義一個接受參數的 Scope。只要開始新增額外參數到你的 Scope。Scope 參數應該在 `$query` 參數之後被定義：
 
     <?php
 
@@ -696,7 +696,7 @@ Sometimes you may wish to define a scope that accepts parameters. To get started
     class User extends Model
     {
         /**
-         * Scope a query to only include users of a given type.
+         * Scopes查詢只有引入給定類型的使用者。
          *
          * @param \Illuminate\Database\Eloquent\Builder $query
          * @param mixed $type
@@ -708,18 +708,18 @@ Sometimes you may wish to define a scope that accepts parameters. To get started
         }
     }
 
-Now, you may pass the parameters when calling the scope:
+現在，你可以在呼叫 scope 的時候傳入該參數：
 
     $users = App\User::ofType('admin')->get();
 
 <a name="events"></a>
-## Events
+## 事件
 
-Eloquent models fire several events, allowing you to hook into the following points in a model's lifecycle: `retrieved`, `creating`, `created`, `updating`, `updated`, `saving`, `saved`, `deleting`, `deleted`, `restoring`, `restored`. Events allow you to easily execute code each time a specific model class is saved or updated in the database.
+Eloquent 模型可以讓你觸發下列模型的生命週期幾個時間點的事件：`retrieved`、`creating`、`created`、`updating`、`updated`、`saving`、`saved`、`deleting`、`deleted`、`restoring`、`restored`。事件可以讓你每次在資料庫中儲存或更新指定的模型類別時，能夠輕易的執行程式碼。
 
-The `retrieved` event will fire when an existing model is retrieved from the database. When a new model is saved for the first time, the `creating` and `created` events will fire. If a model already existed in the database and the `save` method is called, the `updating` / `updated` events will fire. However, in both cases, the `saving` / `saved` events will fire.
+從資料庫中取得已存在的資料時，會觸發 `retrieved` 事件。當新的資料被第一次儲存時，會觸發 `creating` 和 `created` 事件。如果資料已經存在於資料庫，並呼叫 `save`，就會觸發 `updating` 和 `updated` 事件。然而，這兩種案例都會觸發 `saving` 和 `saved` 事件。
 
-To get started, define a `$dispatchesEvents` property on your Eloquent model that maps various points of the Eloquent model's lifecycle to your own [event classes](/docs/{{version}}/events):
+請開始在你的 Eloquent 模型上定義 `$dispatchesEvents` 屬性，會映射 Eloquent 模型的生命週期的各個時間點到你的[事件類別](/docs/{{version}}/events):
 
     <?php
 
@@ -735,7 +735,7 @@ To get started, define a `$dispatchesEvents` property on your Eloquent model tha
         use Notifiable;
 
         /**
-         * The event map for the model.
+         * 為模型事件映射。
          *
          * @var array
          */
@@ -746,9 +746,9 @@ To get started, define a `$dispatchesEvents` property on your Eloquent model tha
     }
 
 <a name="observers"></a>
-### Observers
+### Observer
 
-If you are listening for many events on a given model, you may use observers to group all of your listeners into a single class. Observers classes have method names which reflect the Eloquent events you wish to listen for. Each of these methods receives the model as their only argument. Laravel does not include a default directory for observers, so you may create any directory you like to house your observer classes:
+如果你在給定模型上監聽多個事件，你可以使用 Observer 來組織你的所有監聽器到單一個類別。Observer 類別有個方法名稱，會反映你想監聽的 Eloquent 事件。這些方法中的每一個都會接收模型作為它們的參數。Laravel 預設並不沒有 Observers 的目錄，不過你可以建立任何你想要的目錄來放置 Observer 類別：
 
     <?php
 
@@ -759,9 +759,9 @@ If you are listening for many events on a given model, you may use observers to 
     class UserObserver
     {
         /**
-         * Listen to the User created event.
+         * 監聽使用者被建立事件。
          *
-         * @param  User  $user
+         * @param  \App\User  $user
          * @return void
          */
         public function created(User $user)
@@ -770,9 +770,9 @@ If you are listening for many events on a given model, you may use observers to 
         }
 
         /**
-         * Listen to the User deleting event.
+         * 監聽使用者正在刪除事件。
          *
-         * @param  User  $user
+         * @param   \App\User  $user
          * @return void
          */
         public function deleting(User $user)
@@ -781,7 +781,7 @@ If you are listening for many events on a given model, you may use observers to 
         }
     }
 
-To register an observer, use the `observe` method on the model you wish to observe. You may register observers in the `boot` method of one of your service providers. In this example, we'll register the observer in the `AppServiceProvider`:
+在模型上使用 `observe` 方法來註冊想要的 observer。你可以在一個服務提供者中使用 `boot` 方法來註冊 Observer。在這個範例中，我們會在 `AppServiceProvider` 中註冊 Observer：
 
     <?php
 
@@ -794,7 +794,7 @@ To register an observer, use the `observe` method on the model you wish to obser
     class AppServiceProvider extends ServiceProvider
     {
         /**
-         * Bootstrap any application services.
+         * 啟動任何應用程式服務。
          *
          * @return void
          */
@@ -804,7 +804,7 @@ To register an observer, use the `observe` method on the model you wish to obser
         }
 
         /**
-         * Register the service provider.
+         * 註冊服務提供者。
          *
          * @return void
          */


### PR DESCRIPTION
## **Translate `eloquent.md` (v5.5)**

1. 已同步原始文件在 11/12 之前的更新。
2. `Scopes` 與 `Observer` 為專有名詞，故保留原文。
3. 這個文件只出現 `model`，沒出現任何 `data` 的單字，但後來發現很多地方出現的 `model` 比較適合翻成資料。
4. `aggregates` 根據台灣 wiki 翻譯為合計。
5. `cursor` 在 Google 翻譯是滑鼠游標，但這邊應該是指資料指標才對。
6. 這個文件看起來只有八百行，但實際上超級多....