### PR TITLE
Translate license.md (v5.5)

### DIFF
--- a/license.md
+++ b/license.md
@@ -6,3 +6,15 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-------
+
+MIT 授權條款（MIT）
+著作權利所有 © Taylor Otwell
+
+軟體的著作權利人依此 MIT 授權條款，將其對於軟體的著作權利授權釋出，只要使用者踐履以下二項 MIT 授權條款敘明的義務性規定，其即享有對此軟體程式及其相關說明文檔自由不受限制地進行利用的權利，範圍包括「使用、重製、修改、合併、出版、散布、再授權、及販售程式重製作品」等諸多方面的應用，而散布程式之人、更可將上述權利傳遞予其後收受程式的後手，倘若其後收受程式之人亦服膺以下二項 MIT 授權條款的義務性規定，則其對程式亦享有與前手運用範圍相同的同一權利。
+
+散布此一軟體程式者，須將本條款其上的「著作權聲明」及以下的「免責聲明」，內嵌於軟體程式及其重製作品的實體之中。
+
+因 MIT 軟體程式的授權模式乃是無償提供，是以在現行法律的架構下可以主張合理的免除擔保責任。MIT 軟體的著作權人或任何的後續散布者，對於其所散布的 MIT 軟體程式皆不負任何形式上實質上的擔保責任，明示亦或隱喻、商業利用性亦或特定目的使用性，這些均不在保障之列。利用 MIT 軟體程式的所有風險均由使用者自行擔負。假如所使用的 MIT 程式發生缺陷性問題，使用者需自行擔負修正、改正及必要的服務支出。MIT 軟體程式的著作權人不負任何形式上實質上的擔保責任，無論任何一般的、特殊的、偶發的、因果關係式的損害，或是 MIT 軟體程式的不適用性，均須由使用者自行負擔。
+


### PR DESCRIPTION
## **Translate `license.md` (v5.5)**

1. 保留英文版的 MIT 授權條款內容
2. 原文很制式，所以直接找網路上翻譯過的版本，出處於：https://goo.gl/n2esjG