### PR TITLE
Translate validation.md (7.x)

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1,58 +1,58 @@
-# Validation
+# 驗證
 
-- [Introduction](#introduction)
-- [Validation Quickstart](#validation-quickstart)
-    - [Defining The Routes](#quick-defining-the-routes)
-    - [Creating The Controller](#quick-creating-the-controller)
-    - [Writing The Validation Logic](#quick-writing-the-validation-logic)
-    - [Displaying The Validation Errors](#quick-displaying-the-validation-errors)
-    - [A Note On Optional Fields](#a-note-on-optional-fields)
-- [Form Request Validation](#form-request-validation)
-    - [Creating Form Requests](#creating-form-requests)
-    - [Authorizing Form Requests](#authorizing-form-requests)
-    - [Customizing The Error Messages](#customizing-the-error-messages)
-    - [Customizing The Validation Attributes](#customizing-the-validation-attributes)
-    - [Prepare Input For Validation](#prepare-input-for-validation)
-- [Manually Creating Validators](#manually-creating-validators)
-    - [Automatic Redirection](#automatic-redirection)
-    - [Named Error Bags](#named-error-bags)
-    - [After Validation Hook](#after-validation-hook)
-- [Working With Error Messages](#working-with-error-messages)
-    - [Custom Error Messages](#custom-error-messages)
-- [Available Validation Rules](#available-validation-rules)
-- [Conditionally Adding Rules](#conditionally-adding-rules)
-- [Validating Arrays](#validating-arrays)
-- [Custom Validation Rules](#custom-validation-rules)
-    - [Using Rule Objects](#using-rule-objects)
-    - [Using Closures](#using-closures)
-    - [Using Extensions](#using-extensions)
-    - [Implicit Extensions](#implicit-extensions)
+- [介紹](#introduction)
+- [驗證快速上手](#validation-quickstart)
+    - [定義路由](#quick-defining-the-routes)
+    - [建立控制器](#quick-creating-the-controller)
+    - [撰寫驗證邏輯](#quick-writing-the-validation-logic)
+    - [顯示驗證錯誤](#quick-displaying-the-validation-errors)
+    - [關於可選欄位的說明](#a-note-on-optional-fields)
+- [表單請求驗證](#form-request-validation)
+    - [建立表單請求](#creating-form-requests)
+    - [授權表單請求](#authorizing-form-requests)
+    - [自訂錯誤訊息](#customizing-the-error-messages)
+    - [自訂驗證屬性](#customizing-the-validation-attributes)
+    - [在驗證輸入之前](#prepare-input-for-validation)
+- [手動建立驗證器](#manually-creating-validators)
+    - [自動重導](#automatic-redirection)
+    - [命名錯誤清單](#named-error-bags)
+    - [驗證後的掛勾](#after-validation-hook)
+- [處理錯誤訊息](#working-with-error-messages)
+    - [自訂錯誤訊息](#custom-error-messages)
+- [可用的驗證規則](#available-validation-rules)
+- [依條件增加規則](#conditionally-adding-rules)
+- [驗證陣列](#validating-arrays)
+- [自訂驗證規則](#custom-validation-rules)
+    - [使用規則物件](#using-rule-objects)
+    - [使用閉包](#using-closures)
+    - [使用擴充功能](#using-extensions)    
+    - [隱式擴充功能](#implicit-extensions)
 
 <a name="introduction"></a>
-## Introduction
+## 介紹
 
-Laravel provides several different approaches to validate your application's incoming data. By default, Laravel's base controller class uses a `ValidatesRequests` trait which provides a convenient method to validate incoming HTTP requests with a variety of powerful validation rules.
+Laravel 提供多種方法來驗證應用程式傳入的資料。預設情況下，Laravel 的基底控制器利用 `ValidatesRequests` trait 提供的一個便利的方法和各種強大的驗證規則來驗證傳入的 HTTP 請求。
 
 <a name="validation-quickstart"></a>
-## Validation Quickstart
+## 驗證快速上手
 
-To learn about Laravel's powerful validation features, let's look at a complete example of validating a form and displaying the error messages back to the user.
+要了解 Laravel 強大的驗證特性，讓我們來看一個驗證表單並顯示錯誤訊息給使用者的完整範例。
 
 <a name="quick-defining-the-routes"></a>
-### Defining The Routes
+### 定義路由
 
-First, let's assume we have the following routes defined in our `routes/web.php` file:
+首先，假設我們在 `routes/web.php` 檔案中定義了下列的路由：
 
     Route::get('post/create', 'PostController@create');
 
     Route::post('post', 'PostController@store');
 
-The `GET` route will display a form for the user to create a new blog post, while the `POST` route will store the new blog post in the database.
+`GET` 路由會顯示讓使用者新增部落格文章的表單，而 `POST` 路由會儲存部落格新文章到資料庫。
 
 <a name="quick-creating-the-controller"></a>
-### Creating The Controller
+### 建立控制器
 
-Next, let's take a look at a simple controller that handles these routes. We'll leave the `store` method empty for now:
+再來，我們來看看一個處理這些路由的簡單的控制器。暫時先把 `store` 方法的內容留白：
 
     <?php
 
@@ -64,7 +64,7 @@ Next, let's take a look at a simple controller that handles these routes. We'll 
     class PostController extends Controller
     {
         /**
-         * Show the form to create a new blog post.
+         * 顯示建立部落格新文章的表單。
          *
          * @return Response
          */
@@ -74,26 +74,26 @@ Next, let's take a look at a simple controller that handles these routes. We'll 
         }
 
         /**
-         * Store a new blog post.
+         * 儲存一篇部落格新文章。
          *
          * @param  Request  $request
          * @return Response
          */
         public function store(Request $request)
         {
-            // Validate and store the blog post...
+            // 驗證並儲存部落格文章...
         }
     }
 
 <a name="quick-writing-the-validation-logic"></a>
-### Writing The Validation Logic
+### 撰寫驗證邏輯
 
-Now we are ready to fill in our `store` method with the logic to validate the new blog post. To do this, we will use the `validate` method provided by the `Illuminate\Http\Request` object. If the validation rules pass, your code will keep executing normally; however, if validation fails, an exception will be thrown and the proper error response will automatically be sent back to the user. In the case of a traditional HTTP request, a redirect response will be generated, while a JSON response will be sent for AJAX requests.
+現在我們可以把驗證部落格新文章的邏輯寫進 `store` 方法中了。我們會使用 `Illuminate\Http\Request` 物件提供的 `validate` 方法來實現驗證。如果通過驗證規則，程式會繼續正常執行；如果驗證失敗，會拋出一個例外並把適當的錯誤訊息回傳給使用者。在傳統的 HTTP 請求中，會產生一個重導回應，對於 AJAX 請求則發送 JSON 回應。
 
-To get a better understanding of the `validate` method, let's jump back into the `store` method:
+為了更理解 `validate` 方法，我們先回到 `store` 方法中：
 
     /**
-     * Store a new blog post.
+     * 儲存一篇部落格新文章。
      *
      * @param  Request  $request
      * @return Response
@@ -105,39 +105,39 @@ To get a better understanding of the `validate` method, let's jump back into the
             'body' => 'required',
         ]);
 
-        // The blog post is valid...
+        // 部落格文章通過驗證...
     }
 
-As you can see, we pass the desired validation rules into the `validate` method. Again, if the validation fails, the proper response will automatically be generated. If the validation passes, our controller will continue executing normally.
+如你所見，我們單純的把所需的驗證規則傳進 `validate` 方法中。再次提醒，如果驗證失敗，會自動產生適當的回應。如果驗證通過，控制器會繼續正常執行。
 
-Alternatively, validation rules may be specified as arrays of rules instead of a single `|` delimited string:
+除此之外，驗證規則可以是規則陣列，而不是單個 `|` 分隔字串：
 
     $validatedData = $request->validate([
         'title' => ['required', 'unique:posts', 'max:255'],
         'body' => ['required'],
     ]);
 
-You may use the `validateWithBag` method to validate a request and store any error messages within a [named error bag](#named-error-bags):
+你可以使用 `validateWithBag` 方法來驗證請求並記錄任何錯誤到[命名錯誤清單](#named-error-bags):
 
     $validatedData = $request->validateWithBag('post', [
         'title' => ['required', 'unique:posts', 'max:255'],
         'body' => ['required'],
     ]);
 
-#### Stopping On First Validation Failure
+#### 在首次驗證失敗時停止驗證
 
-Sometimes you may wish to stop running validation rules on an attribute after the first validation failure. To do so, assign the `bail` rule to the attribute:
+有時候你會希望在一個屬性首次驗證失敗時，停止此屬性的其他驗證規則。把 `bail` 規則指派到屬性中來達成目的：
 
     $request->validate([
         'title' => 'bail|required|unique:posts|max:255',
         'body' => 'required',
     ]);
 
-In this example, if the `unique` rule on the `title` attribute fails, the `max` rule will not be checked. Rules will be validated in the order they are assigned.
+在這個範例中，如果 `title` 屬性的 `unique` 規則驗證失敗，就不會檢查 `max` 規則。驗證的順序會依照規則指派的順序。
 
-#### A Note On Nested Attributes
+#### 關於巢狀屬性的提醒
 
-If your HTTP request contains "nested" parameters, you may specify them in your validation rules using "dot" syntax:
+如果 HTTP 請求包含了「巢狀」參數，可以在驗證規則中使用「點」語法來指定屬性：
 
     $request->validate([
         'title' => 'required|unique:posts|max:255',
@@ -146,19 +146,19 @@ If your HTTP request contains "nested" parameters, you may specify them in your 
     ]);
 
 <a name="quick-displaying-the-validation-errors"></a>
-### Displaying The Validation Errors
+### 顯示驗證錯誤
 
-So, what if the incoming request parameters do not pass the given validation rules? As mentioned previously, Laravel will automatically redirect the user back to their previous location. In addition, all of the validation errors will automatically be [flashed to the session](/docs/{{version}}/session#flash-data).
+那麼當傳入的要求參數沒有通過指定的驗證規則呢？如之前提到，Laravel 會自動把使用者導回先前的位置。另外，所有的驗證錯誤會自動[快閃到 session](/docs/{{version}}/session#flash-data)。
 
-Again, notice that we did not have to explicitly bind the error messages to the view in our `GET` route. This is because Laravel will check for errors in the session data, and automatically bind them to the view if they are available. The `$errors` variable will be an instance of `Illuminate\Support\MessageBag`. For more information on working with this object, [check out its documentation](#working-with-error-messages).
+注意到我們在 `GET` 路由中不需要明確地綁定錯誤訊息到視圖。這是因為 Laravel 會自動檢查 session 內的錯誤資料，如果錯誤存在的話，會自動綁定這些錯誤訊息到視圖。`$errors` 變數會是 `Illuminate\Support\MessageBag` 的實例。有關此物件的詳細資訊，[請查閱它的文件](#working-with-error-messages)。
 
-> {tip} The `$errors` variable is bound to the view by the `Illuminate\View\Middleware\ShareErrorsFromSession` middleware, which is provided by the `web` middleware group. **When this middleware is applied an `$errors` variable will always be available in your views**, allowing you to conveniently assume the `$errors` variable is always defined and can be safely used.
+> {tip} `$errors` 變數透過 `web` 中介層群組提供的 `Illuminate\View\Middleware\ShareErrorsFromSession` 中介層綁定到視圖。**當應用這個中介層時，視圖中會永遠存在一個可用的 `$errors` 變數**，你可以方便的假設 `$errors` 變數總是有被定義且可以安全使用。
 
-So, in our example, the user will be redirected to our controller's `create` method when validation fails, allowing us to display the error messages in the view:
+在我們的範例中，驗證失敗時會將使用者重導到控制器的 `create` 方法，讓我們可以在這個視圖中顯示錯誤訊息：
 
     <!-- /resources/views/post/create.blade.php -->
 
-    <h1>Create Post</h1>
+    <h1>新增文章</h1>
 
     @if ($errors->any())
         <div class="alert alert-danger">
@@ -170,11 +170,11 @@ So, in our example, the user will be redirected to our controller's `create` met
         </div>
     @endif
 
-    <!-- Create Post Form -->
+    <!-- 新增文章表單 -->
 
-#### The `@error` Directive
+#### `@error` 語法糖
 
-You may also use the `@error` [Blade](/docs/{{version}}/blade) directive to quickly check if validation error messages exist for a given attribute. Within an `@error` directive, you may echo the `$message` variable to display the error message:
+你可以使用 `@error` [Blade](/docs/{{version}}/blade) 語法糖來快速檢查給定的屬性是否有錯誤訊息。可以在 `@error` 語法糖內呼叫 `$message` 變數來顯示錯誤訊息：
 
     <!-- /resources/views/post/create.blade.php -->
 
@@ -187,9 +187,9 @@ You may also use the `@error` [Blade](/docs/{{version}}/blade) directive to quic
     @enderror
 
 <a name="a-note-on-optional-fields"></a>
-### A Note On Optional Fields
+### 關於可選欄位的說明
 
-By default, Laravel includes the `TrimStrings` and `ConvertEmptyStringsToNull` middleware in your application's global middleware stack. These middleware are listed in the stack by the `App\Http\Kernel` class. Because of this, you will often need to mark your "optional" request fields as `nullable` if you do not want the validator to consider `null` values as invalid. For example:
+Laravel 預設會在全域的中介層堆疊中加入 `TrimStrings` 和 `ConvertEmptyStringsToNull` 中介層。`App\Http\Kernel` 類別中列出了堆疊內的中介層。因此，如果你不想讓驗證器認為 `null` 值無效，你通常會需要把「可選」的請求欄位標註為 `nullable`。例如：
 
     $request->validate([
         'title' => 'required|unique:posts|max:255',
@@ -197,27 +197,27 @@ By default, Laravel includes the `TrimStrings` and `ConvertEmptyStringsToNull` m
         'publish_at' => 'nullable|date',
     ]);
 
-In this example, we are specifying that the `publish_at` field may be either `null` or a valid date representation. If the `nullable` modifier is not added to the rule definition, the validator would consider `null` an invalid date.
+在這個範例中，我們指定 `publish_at` 欄位可以為 `null` 或一個有效的日期表示。如果沒有把 `nullable` 修飾字加到規則定義中，驗證器會認為 `null` 是無效的日期。
 
 <a name="quick-ajax-requests-and-validation"></a>
-#### AJAX Requests & Validation
+#### AJAX 請求和驗證
 
-In this example, we used a traditional form to send data to the application. However, many applications use AJAX requests. When using the `validate` method during an AJAX request, Laravel will not generate a redirect response. Instead, Laravel generates a JSON response containing all of the validation errors. This JSON response will be sent with a 422 HTTP status code.
+在這個範例中，我們使用傳統的表單來發送資料給應用程式。然而，許多應用程式是利用 AJAX 請求。在 AJAX 請求時使用 `validate` 方法，Laravel 不會產生重導回應。而是會產生一個包含所有驗證錯誤的 JSON 回應。此 JSON 回應會包含 422 HTTP 狀態碼。
 
 <a name="form-request-validation"></a>
-## Form Request Validation
+## 表單請求驗證
 
 <a name="creating-form-requests"></a>
-### Creating Form Requests
+### 建立表單請求
 
-For more complex validation scenarios, you may wish to create a "form request". Form requests are custom request classes that contain validation logic. To create a form request class, use the `make:request` Artisan CLI command:
+在更複雜的驗證情境中，你可能會想建立一個「表單請求」。表單請求是一種自訂的請求類別，其中包含驗證邏輯。使用 Artisan 命令列指令 `make:request` 來建立一個表單請求類別：
 
     php artisan make:request StoreBlogPost
 
-The generated class will be placed in the `app/Http/Requests` directory. If this directory does not exist, it will be created when you run the `make:request` command. Let's add a few validation rules to the `rules` method:
+新產生的類別檔會放在 `app/Http/Requests` 目錄下。如果目錄不存在，會在執行 `make:request` 時建立。讓我們加入一些驗證規則到 rules 方法中：
 
     /**
-     * Get the validation rules that apply to the request.
+     * 取得適用於請求的驗證規則。
      *
      * @return array
      */
@@ -229,32 +229,32 @@ The generated class will be placed in the `app/Http/Requests` directory. If this
         ];
     }
 
-> {tip} You may type-hint any dependencies you need within the `rules` method's signature. They will automatically be resolved via the Laravel [service container](/docs/{{version}}/container).
+> {tip} 你可以在 `rules` 方法參數中加入任何你需要的依賴項目。他們會自動透過 Laravel [服務容器]](/docs/{{version}}/container)來解析。
 
-So, how are the validation rules evaluated? All you need to do is type-hint the request on your controller method. The incoming form request is validated before the controller method is called, meaning you do not need to clutter your controller with any validation logic:
+那驗證的規則會如何執行呢？只需要在控制器方法中，為請求加上型別提示。傳入的表單請求會在控制器方法被呼叫前進行驗證，也就是說不會因為驗證邏輯而把控制器弄得一團亂：
 
     /**
-     * Store the incoming blog post.
+     * 儲存傳入的部落格文章。
      *
      * @param  StoreBlogPost  $request
      * @return Response
      */
     public function store(StoreBlogPost $request)
     {
-        // The incoming request is valid...
+        // 有效的傳入請求...
 
-        // Retrieve the validated input data...
+        // 取得已驗證過的資料...
         $validated = $request->validated();
     }
 
-If validation fails, a redirect response will be generated to send the user back to their previous location. The errors will also be flashed to the session so they are available for display. If the request was an AJAX request, a HTTP response with a 422 status code will be returned to the user including a JSON representation of the validation errors.
+如果驗證失敗，會產生一個重導回應把使用者導回先前的位置。這些錯誤會被快閃至 session，讓錯誤都可以被顯示。如果是 AJAX 請求，則會傳回包含 422 狀態碼及驗證錯誤的 JSON 資料的 HTTP 回應。
 
-#### Adding After Hooks To Form Requests
+#### 為表單請求加上驗證後的掛勾
 
-If you would like to add an "after" hook to a form request, you may use the `withValidator` method. This method receives the fully constructed validator, allowing you to call any of its methods before the validation rules are actually evaluated:
+如果想要為表單請求加上「驗證後」的掛勾，可以利用 `withValidator` 方法。這個方法接收完整建構的驗證器，讓你可以在驗證規則實際被執行前呼叫驗證器的任何方法：
 
     /**
-     * Configure the validator instance.
+     * 設定驗證器實例。
      *
      * @param  \Illuminate\Validation\Validator  $validator
      * @return void
@@ -269,12 +269,12 @@ If you would like to add an "after" hook to a form request, you may use the `wit
     }
 
 <a name="authorizing-form-requests"></a>
-### Authorizing Form Requests
+### 授權表單請求
 
-The form request class also contains an `authorize` method. Within this method, you may check if the authenticated user actually has the authority to update a given resource. For example, you may determine if a user actually owns a blog comment they are attempting to update:
+表單請求類別也包含了 `authorize` 方法。在這個方法中，你可以確認使用者是否真的有權限可以更新特定資料。舉個例子，當一個使用者嘗試更新部落格文章的評論時，可以先判斷這是否是他的評論？例如：
 
     /**
-     * Determine if the user is authorized to make this request.
+     * 判斷使用者是否有權限做出此請求。
      *
      * @return bool
      */
@@ -285,16 +285,16 @@ The form request class also contains an `authorize` method. Within this method, 
         return $comment && $this->user()->can('update', $comment);
     }
 
-Since all form requests extend the base Laravel request class, we may use the `user` method to access the currently authenticated user. Also note the call to the `route` method in the example above. This method grants you access to the URI parameters defined on the route being called, such as the `{comment}` parameter in the example below:
+因為所有的表單請求都是繼承 Laravel 基底的請求類別，我們可以利用 `user` 方法來存取當下認證的使用者。同時注意到上面範例中有呼叫 `route` 方法。這個方法讓你可以取得呼叫路由時的 URI 參數，像是如下範例的 `{comment}` 參數：
 
     Route::post('comment/{comment}');
 
-If the `authorize` method returns `false`, a HTTP response with a 403 status code will automatically be returned and your controller method will not execute.
+如果 `authorize` 方法回傳 `false`，會自動回傳一個包含 403 狀態碼的 HTTP 回應，且不會執行控制器方法。
 
-If you plan to have authorization logic in another part of your application, return `true` from the `authorize` method:
+如果你打算在應用程式的其他部分處理授權邏輯，只需讓 `authorize` 方法回傳 `true`：
 
     /**
-     * Determine if the user is authorized to make this request.
+     * 判斷使用者是否有權限做出此請求。
      *
      * @return bool
      */
@@ -303,15 +303,15 @@ If you plan to have authorization logic in another part of your application, ret
         return true;
     }
 
-> {tip} You may type-hint any dependencies you need within the `authorize` method's signature. They will automatically be resolved via the Laravel [service container](/docs/{{version}}/container).
+> {tip} 你可以在 `authorize` 方法參數中加入任何你需要的依賴項目。他們會自動透過 Laravel [服務容器]](/docs/{{version}}/container)來解析。
 
 <a name="customizing-the-error-messages"></a>
-### Customizing The Error Messages
+### 自訂錯誤訊息
 
-You may customize the error messages used by the form request by overriding the `messages` method. This method should return an array of attribute / rule pairs and their corresponding error messages:
+你可以透過覆寫表單請求的 `messages` 方法來自定錯誤訊息。此方法必須回傳一個包含成對的屬性與規則及對應錯誤訊息的陣列：
 
     /**
-     * Get the error messages for the defined validation rules.
+     * 取得已定義驗證規則的錯誤訊息。
      *
      * @return array
      */
@@ -324,12 +324,12 @@ You may customize the error messages used by the form request by overriding the 
     }
 
 <a name="customizing-the-validation-attributes"></a>
-### Customizing The Validation Attributes
+### 自訂驗證屬性
 
-If you would like the `:attribute` portion of your validation message to be replaced with a custom attribute name, you may specify the custom names by overriding the `attributes` method. This method should return an array of attribute / name pairs:
+如果想要自訂屬性名稱來替換驗證訊息的 `:attribute` 部分，你可以透過覆寫 `attributes` 方法來指定自訂的名稱。這個方法會回傳一組屬性與名稱的陣列：
 
     /**
-     * Get custom attributes for validator errors.
+     * 取得自訂的驗證器錯誤屬性。
      *
      * @return array
      */
@@ -341,14 +341,14 @@ If you would like the `:attribute` portion of your validation message to be repl
     }
 
 <a name="prepare-input-for-validation"></a>
-### Prepare Input For Validation
+### 在驗證輸入之前
 
-If you need to sanitize any data from the request before you apply your validation rules, you can use the `prepareForValidation` method:
+如果你需要在驗證規則之前先修飾請求中的任何資料。你能用 `prepareForValidation` 方法：
 
     use Illuminate\Support\Str;
 
     /**
-     * Prepare the data for validation.
+     * 在驗證輸入之前。
      *
      * @return void
      */
@@ -360,9 +360,9 @@ If you need to sanitize any data from the request before you apply your validati
     }
 
 <a name="manually-creating-validators"></a>
-## Manually Creating Validators
+## 手動建立驗證器
 
-If you do not want to use the `validate` method on the request, you may create a validator instance manually using the `Validator` [facade](/docs/{{version}}/facades). The `make` method on the facade generates a new validator instance:
+如果你不想要用請求的 `validate` 方法，你可以透過 `Validator` [facade](/docs/{{version}}/facades) 來建立驗證器實例。Facade 中的 `make` 方法會產生一個新的驗證器實例。
 
     <?php
 
@@ -375,7 +375,7 @@ If you do not want to use the `validate` method on the request, you may create a
     class PostController extends Controller
     {
         /**
-         * Store a new blog post.
+         * 儲存部落格新文章。
          *
          * @param  Request  $request
          * @return Response
@@ -393,25 +393,25 @@ If you do not want to use the `validate` method on the request, you may create a
                             ->withInput();
             }
 
-            // Store the blog post...
+            // 儲存部落格文章...
         }
     }
 
-The first argument passed to the `make` method is the data under validation. The second argument is the validation rules that should be applied to the data.
+傳給 `make` 方法的第一個參數是需要被驗證的資料。第二個參數是資料使用的驗證規則。
 
-After checking if the request validation failed, you may use the `withErrors` method to flash the error messages to the session. When using this method, the `$errors` variable will automatically be shared with your views after redirection, allowing you to easily display them back to the user. The `withErrors` method accepts a validator, a `MessageBag`, or a PHP `array`.
+檢查請求是否有驗證通過後，你可以使用 `withErrors` 方法把錯誤訊息快閃到 session。使用這個方法，在重導之後 `$errors` 變數可以自動的在視圖中共用，讓你輕鬆地顯示這些訊息給使用者。`withErrors` 方法接受驗證器、`MessageBag`，或是 PHP `array`。
 
 <a name="automatic-redirection"></a>
-### Automatic Redirection
+### 自動重導
 
-If you would like to create a validator instance manually but still take advantage of the automatic redirection offered by the request's `validate` method, you may call the `validate` method on an existing validator instance. If validation fails, the user will automatically be redirected or, in the case of an AJAX request, a JSON response will be returned:
+如果在手動建立驗證器的同時，仍然想利用請求的 `validate` 方法所提供的自動重導，你可以呼叫現有的驗證器實體的 `validate` 方法。如果驗證失敗，使用者會被自動重導，或在 AJAX 請求時回傳 JSON 回應：
 
     Validator::make($request->all(), [
         'title' => 'required|unique:posts|max:255',
         'body' => 'required',
     ])->validate();
 
-You may use the `validateWithBag` method to store the error messages in a [named error bag](#named-error-bags) if validation fails:
+你可以使用 `validateWithBag` 方法在驗證失敗的時候將錯誤訊息記錄到[命名錯誤清單](#named-error-bags)：
 
     Validator::make($request->all(), [
         'title' => 'required|unique:posts|max:255',
@@ -419,21 +419,21 @@ You may use the `validateWithBag` method to store the error messages in a [named
     ])->validateWithBag('post');
 
 <a name="named-error-bags"></a>
-### Named Error Bags
+### 命名錯誤清單
 
-If you have multiple forms on a single page, you may wish to name the `MessageBag` of errors, allowing you to retrieve the error messages for a specific form. Pass a name as the second argument to `withErrors`:
+假如在一個頁面中有多個表單，你可能希望為每個錯誤的 `MessageBag` 命名，這樣就可以取得特定表單的錯誤訊息。只要在 `withErrors` 的第二個參數傳入名稱即可：
 
     return redirect('register')
                 ->withErrors($validator, 'login');
 
-You may then access the named `MessageBag` instance from the `$errors` variable:
+再來就可以從 `$errors` 變數中取得已命名的 `MessageBag` 實例：
 
     {{ $errors->login->first('email') }}
 
 <a name="after-validation-hook"></a>
-### After Validation Hook
+### 驗證後的掛勾
 
-The validator also allows you to attach callbacks to be run after validation is completed. This allows you to easily perform further validation and even add more error messages to the message collection. To get started, use the `after` method on a validator instance:
+驗證器可以附加回呼以在驗證完成後執行。可以讓你更簡單的做進一步驗證甚至在錯誤訊息集合中增加更多錯誤訊息。在驗證器實例使用 `after` 方法即可：
 
     $validator = Validator::make(...);
 
@@ -448,52 +448,52 @@ The validator also allows you to attach callbacks to be run after validation is 
     }
 
 <a name="working-with-error-messages"></a>
-## Working With Error Messages
+## 處理錯誤訊息
 
-After calling the `errors` method on a `Validator` instance, you will receive an `Illuminate\Support\MessageBag` instance, which has a variety of convenient methods for working with error messages. The `$errors` variable that is automatically made available to all views is also an instance of the `MessageBag` class.
+呼叫 `Validator` 實例的 `errors` 方法，會得到一個 `Illuminate\Support\MessageBag` 的實例，其中有許多方便的方法讓你處理錯誤訊息。在所有視圖中共用的 `$errors` 變數就是 `MessageBag` 類別的實例。
 
-#### Retrieving The First Error Message For A Field
+#### 取出特定欄位的第一個錯誤訊息
 
-To retrieve the first error message for a given field, use the `first` method:
+使用 `first` 方法來取出特定欄位的第一個錯誤訊息
 
     $errors = $validator->errors();
 
     echo $errors->first('email');
 
-#### Retrieving All Error Messages For A Field
+#### 取出特定欄位的所有錯誤訊息
 
-If you need to retrieve an array of all the messages for a given field, use the `get` method:
+使用 `get` 方法來取出特定欄位所有訊息的陣列：
 
     foreach ($errors->get('email') as $message) {
         //
     }
 
-If you are validating an array form field, you may retrieve all of the messages for each of the array elements using the `*` character:
+如果你驗證的表單欄位是個陣列，可以用 `*` 字元來取出每個陣列元素的訊息：
 
     foreach ($errors->get('attachments.*') as $message) {
         //
     }
 
-#### Retrieving All Error Messages For All Fields
+#### 取出所有欄位的所有錯誤訊息
 
-To retrieve an array of all messages for all fields, use the `all` method:
+使用 `all` 方法來取出所有欄位的所有錯誤訊息：
 
     foreach ($errors->all() as $message) {
         //
     }
 
-#### Determining If Messages Exist For A Field
+#### 判斷特定欄位是否有錯誤訊息
 
-The `has` method may be used to determine if any error messages exist for a given field:
+使用 `has` 方法來判斷特定欄位是否有錯誤訊息：
 
     if ($errors->has('email')) {
         //
     }
 
 <a name="custom-error-messages"></a>
-### Custom Error Messages
+### 自訂錯誤訊息
 
-If needed, you may use custom error messages for validation instead of the defaults. There are several ways to specify custom messages. First, you may pass the custom messages as the third argument to the `Validator::make` method:
+如果有需要，你可以自訂驗證的錯誤訊息來取代預設的錯誤訊息。有數種指定自訂訊息的方法。第一種，把自訂的訊息傳到 `Validator::make` 方法的第三個參數：
 
     $messages = [
         'required' => 'The :attribute field is required.',
@@ -501,78 +501,78 @@ If needed, you may use custom error messages for validation instead of the defau
 
     $validator = Validator::make($input, $rules, $messages);
 
-In this example, the `:attribute` placeholder will be replaced by the actual name of the field under validation. You may also utilize other placeholders in validation messages. For example:
+在這個範例中，`:attribute` 佔位符會被驗證時實際的欄位名稱給取代。也有其他的佔位符可以在驗證訊息中使用。例如：
 
     $messages = [
-        'same' => 'The :attribute and :other must match.',
-        'size' => 'The :attribute must be exactly :size.',
-        'between' => 'The :attribute value :input is not between :min - :max.',
-        'in' => 'The :attribute must be one of the following types: :values',
+        'same' => ':attribute 和 :other 必須相同。',
+        'size' => ':attribute 的大小必須是 :size。',
+        'between' => ':attribute 必須介於 :min - :max 之間。',
+        'in' => ':attribute 必須是以下的類型之一：:values',
     ];
 
-#### Specifying A Custom Message For A Given Attribute
+#### 指定自訂訊息給特定的屬性
 
-Sometimes you may wish to specify a custom error message only for a specific field. You may do so using "dot" notation. Specify the attribute's name first, followed by the rule:
+有時候你可能想要對特定的欄位自訂錯誤訊息。在你的屬性名稱後加上「.」符號，並加上指定的驗證規則：
 
     $messages = [
-        'email.required' => 'We need to know your e-mail address!',
+        'email.required' => '我們需要知道你的 e-mail 位址！',
     ];
 
 <a name="localization"></a>
-#### Specifying Custom Messages In Language Files
+#### 在語系檔中指定自訂訊息
 
-In most cases, you will probably specify your custom messages in a language file instead of passing them directly to the `Validator`. To do so, add your messages to `custom` array in the `resources/lang/xx/validation.php` language file.
+在大部分情況下，你可能會希望在語系檔中指定自訂的訊息，而不是被直接傳進 `Validator`。把訊息加到 `resources/lang/xx/validation.php` 語言檔中的 `custom` 陣列來達成目的。
 
     'custom' => [
         'email' => [
-            'required' => 'We need to know your e-mail address!',
+            'required' => '我們需要知道你的 e-mail 位址！',
         ],
     ],
 
-#### Specifying Custom Attribute Values
+#### 指定自訂的屬性值
 
-If you would like the `:attribute` portion of your validation message to be replaced with a custom attribute name, you may specify the custom name in the `attributes` array of your `resources/lang/xx/validation.php` language file:
+若想要自訂屬性名稱來替換驗證訊息的 `:attribute` 部分，你可以在 `resources/lang/xx/validation.php` 語系檔的 `attributes` 陣列中指定自訂名稱：
 
     'attributes' => [
-        'email' => 'email address',
+        'email' => 'email 位置',
     ],
 
-You may also pass the custom attributes as the fourth argument to the `Validator::make` method:
+你也可以傳入自訂屬性到 `Validator::make` 方法的第四個參數：
 
     $customAttributes = [
-        'email' => 'email address',
+        'email' => 'email 位置',
     ];
 
     $validator = Validator::make($input, $rules, $messages, $customAttributes);
 
-#### Specifying Custom Values In Language Files
+#### 在語系檔中指定自訂值
 
-Sometimes you may need the `:value` portion of your validation message to be replaced with a custom representation of the value. For example, consider the following rule that specifies that a credit card number is required if the `payment_type` has a value of `cc`:
+有時你需要將驗證訊息的 `:value` 部分換成自訂的值。例如，下列示範為如果 `payment_type` 的值為 `cc` 則需要信用卡號：
 
     $request->validate([
         'credit_card_number' => 'required_if:payment_type,cc'
     ]);
 
-If this validation rule fails, it will produce the following error message:
+如果驗證該規則失敗，就會產生以下錯誤訊息：
 
     The credit card number field is required when payment type is cc.
 
-Instead of displaying `cc` as the payment type value, you may specify a custom value representation in your `validation` language file by defining a `values` array:
+`cc` 除了作為付款類型的值來顯示外，你可以在 `validation` 語系檔中的 `values` 陣列來定義特定的值來表示：
 
     'values' => [
         'payment_type' => [
-            'cc' => 'credit card'
+            'cc' => '信用卡'
         ],
     ],
 
-Now if the validation rule fails it will produce the following message:
+如果現在驗證失敗時，則會產生以下訊息：
 
-    The credit card number field is required when payment type is credit card.
+    The credit card number field is required when payment type is 信用卡.
 
 <a name="available-validation-rules"></a>
-## Available Validation Rules
+## 可用的驗證規則
 
-Below is a list of all available validation rules and their function:
+以下是所有可用的驗證規則與功能：
 
 <style>
     .collection-method-list > p {
@@ -659,123 +659,123 @@ Below is a list of all available validation rules and their function:
 <a name="rule-accepted"></a>
 #### accepted
 
-The field under validation must be _yes_, _on_, _1_, or _true_. This is useful for validating "Terms of Service" acceptance.
+驗證欄位值是否為 _yes_、_on_、_1_、或 _true_。這在確認是否同意「服務條款」時很有用。
 
 <a name="rule-active-url"></a>
 #### active_url
 
-The field under validation must have a valid A or AAAA record according to the `dns_get_record` PHP function. The hostname of the provided URL is extracted using the `parse_url` PHP function before being passed to `dns_get_record`.
+透過 PHP 的 `dns_get_record` 函式來驗證欄位是否為有效的 A 或 AAAA 紀錄。會在開始傳入 `dns_get_record` 之前使用 PHP 的 `parse_url` 函數來取得提供 URL 的主機名稱。
 
 <a name="rule-after"></a>
 #### after:_date_
 
-The field under validation must be a value after a given date. The dates will be passed into the `strtotime` PHP function:
+驗證欄位是否是在指定日期之後的值。這個日期會透過 PHP `strtotime` 函式驗證。
 
     'start_date' => 'required|date|after:tomorrow'
 
-Instead of passing a date string to be evaluated by `strtotime`, you may specify another field to compare against the date:
+或者指定另一個用來比較的日期欄位，而不是透過傳給 `strtotime` 的字串：
 
     'finish_date' => 'required|date|after:start_date'
 
 <a name="rule-after-or-equal"></a>
 #### after\_or\_equal:_date_
 
-The field under validation must be a value after or equal to the given date. For more information, see the [after](#rule-after) rule.
+驗證欄位是否在指定日期之後或同一天。更多資訊請參考 [after](#rule-after) 規則。
 
 <a name="rule-alpha"></a>
 #### alpha
 
-The field under validation must be entirely alphabetic characters.
+驗證欄位值是否僅包含字母及數字。
 
 <a name="rule-alpha-dash"></a>
 #### alpha_dash
 
-The field under validation may have alpha-numeric characters, as well as dashes and underscores.
+驗證欄位值是否僅包含字母、數字、破折號（ - ）以及底線（ _ ）。
 
 <a name="rule-alpha-num"></a>
 #### alpha_num
 
-The field under validation must be entirely alpha-numeric characters.
+驗證欄位值是否僅包含字母及數字。
 
 <a name="rule-array"></a>
 #### array
 
-The field under validation must be a PHP `array`.
+驗證欄位必須是一個 PHP `array`。
 
 <a name="rule-bail"></a>
 #### bail
 
-Stop running validation rules after the first validation failure.
+在第一次驗證失敗後，停止繼續驗證規則。
 
 <a name="rule-before"></a>
 #### before:_date_
 
-The field under validation must be a value preceding the given date. The dates will be passed into the PHP `strtotime` function. In addition, like the [`after`](#rule-after) rule, the name of another field under validation may be supplied as the value of `date`.
+驗證欄位是否是在指定日期之前。這個日期會透過 PHP `strtotime` 函式驗證。此外，可以像 [`after`](#rule-after) 規則一樣，將另一個正在驗證的欄位名稱作為 `date` 的值來驗證。
 
 <a name="rule-before-or-equal"></a>
 #### before\_or\_equal:_date_
 
-The field under validation must be a value preceding or equal to the given date. The dates will be passed into the PHP `strtotime` function. In addition, like the [`after`](#rule-after) rule, the name of another field under validation may be supplied as the value of `date`.
+驗證欄位是否在指定日期之前或同一天。這個日期會透過 PHP `strtotime` 函式驗證。可以像 [`after`](#rule-after) 規則一樣，將另一個正在驗證的欄位名稱作為 `date` 的值來驗證。
 
 <a name="rule-between"></a>
 #### between:_min_,_max_
 
-The field under validation must have a size between the given _min_ and _max_. Strings, numerics, arrays, and files are evaluated in the same fashion as the [`size`](#rule-size) rule.
+驗證欄位值的大小是否介於指定的 _min_ 和 _max_ 之間。字串、數值、陣列和檔案大小的計算方式和 [`size`](#rule-size) 規則相同。
 
 <a name="rule-boolean"></a>
 #### boolean
 
-The field under validation must be able to be cast as a boolean. Accepted input are `true`, `false`, `1`, `0`, `"1"`, and `"0"`.
+驗證欄位值必須能夠轉型為布林值。可接受的輸入為 `true`、`false`、`1`、`0`、`"1"` 以及 `"0"`。
 
 <a name="rule-confirmed"></a>
 #### confirmed
 
-The field under validation must have a matching field of `foo_confirmation`. For example, if the field under validation is `password`, a matching `password_confirmation` field must be present in the input.
+驗證欄位值必須和對應的 `foo_confirmation` 欄位值相同。例如，如果要驗證 `password` 欄位，必須和輸入資料裡的 `password_confirmation` 欄位值相同。
 
 <a name="rule-date"></a>
 #### date
 
-The field under validation must be a valid, non-relative date according to the `strtotime` PHP function.
+驗證欄位值是有效的日期，會透過 PHP 的 `strtotime` 函式驗證。
 
 <a name="rule-date-equals"></a>
 #### date_equals:_date_
 
-The field under validation must be equal to the given date. The dates will be passed into the PHP `strtotime` function.
+驗證欄位是否與指定日期同一天。這個日期會透過 PHP `strtotime` 函式驗證。
 
 <a name="rule-date-format"></a>
 #### date_format:_format_
 
-The field under validation must match the given _format_. You should use **either** `date` or `date_format` when validating a field, not both. This validation rule supports all formats supported by PHP's [DateTime](https://www.php.net/manual/en/class.datetime.php) class.
+驗證欄位值符合定義的日期格式（ _format_ ）。你應該使用 `date` 或 `date_format` **其一**來驗證欄位，而不是兩者。這個驗證規則支援 PHP 的 [DateTime](https://www.php.net/manual/en/class.datetime.php) 類別的所有格式。
 
 <a name="rule-different"></a>
 #### different:_field_
 
-The field under validation must have a different value than _field_.
+驗證欄位值是否和指定的欄位（ _field_ ）不同。
 
 <a name="rule-digits"></a>
 #### digits:_value_
 
-The field under validation must be _numeric_ and must have an exact length of _value_.
+驗證欄位值為長度為 _value_ 的_數字_。
 
 <a name="rule-digits-between"></a>
 #### digits_between:_min_,_max_
 
-The field under validation must be _numeric_ and must have a length between the given _min_ and _max_.
+驗證的欄位必須是 _numeric_，且長度必須介於給定的 _min_ 和 _max_ 之間。
 
 <a name="rule-dimensions"></a>
 #### dimensions
 
-The file under validation must be an image meeting the dimension constraints as specified by the rule's parameters:
+驗證欄位值必須是一張圖片且符合規則參數限制的尺寸：
 
     'avatar' => 'dimensions:min_width=100,min_height=200'
 
-Available constraints are: _min\_width_, _max\_width_, _min\_height_, _max\_height_, _width_, _height_, _ratio_.
+可用的限制為：_min\_width_、_max\_width_、_min\_height_、_max\_height_、_width_、_height_、_ratio_。
 
-A _ratio_ constraint should be represented as width divided by height. This can be specified either by a statement like `3/2` or a float like `1.5`:
+_ratio_ 為寬除以高的比例。可以運算式 `3/2` 或浮點數 `1.5` 來表示：
 
     'avatar' => 'dimensions:ratio=3/2'
 
-Since this rule requires several arguments, you may use the `Rule::dimensions` method to fluently construct the rule:
+由於此規則需要許多參數，你可以用 `Rule::dimensions` 方法來流暢地建構這個規則：
 
     use Illuminate\Validation\Rule;
 
@@ -789,18 +789,18 @@ Since this rule requires several arguments, you may use the `Rule::dimensions` m
 <a name="rule-distinct"></a>
 #### distinct
 
-When working with arrays, the field under validation must not have any duplicate values.
+當處理陣列時，驗證欄位中不能有任何重複的值。
 
     'foo.*.id' => 'distinct'
 
 <a name="rule-email"></a>
 #### email
 
-The field under validation must be formatted as an e-mail address. Under the hood, this validation rule makes use of the [`egulias/email-validator`](https://github.com/egulias/EmailValidator) package for validating the email address. By default the `RFCValidation` validator is applied, but you can apply other validation styles as well:
+驗證欄位必須為一個 e-mail 地址。這個驗證規則會使用 [`egulias/email-validator`](https://github.com/egulias/EmailValidator) 套件來驗證 e-mail 位置。預設會使用 `RFCValidation` 驗證器，但你可以採用其他驗證器格式：
 
     'email' => 'email:rfc,dns'
 
-The example above will apply the `RFCValidation` and `DNSCheckValidation` validations. Here's a full list of validation styles you can apply:
+下列範例會採用 `RFCValidation` 和 `DNSCheckValidation` 驗證器。這裡列出所有可用的驗證器格式：
 
 <div class="content-list" markdown="1">
 - `rfc`: `RFCValidation`
@@ -810,47 +810,47 @@ The example above will apply the `RFCValidation` and `DNSCheckValidation` valida
 - `filter`: `FilterEmailValidation`
 </div>
 
-The `filter` validator, which uses PHP's `filter_var` function under the hood, ships with Laravel and is Laravel's pre-5.8 behavior. The `dns` and `spoof` validators require the PHP `intl` extension.
+`filter` 驗證器使用 PHP 的 `filter_var` 函式，與 Laravel 5.8 用法相同。`dns`和`spoof`驗證器需要 PHP `intl` 擴充功能。
 
 <a name="rule-ends-with"></a>
 #### ends_with:_foo_,_bar_,...
 
-The field under validation must end with one of the given values.
+驗證欄位的結尾是否有給定的值。
 
 <a name="rule-exclude-if"></a>
 #### exclude_if:_anotherfield_,_value_
 
-The field under validation will be excluded from the request data returned by the `validate` and `validated` methods if the _anotherfield_ field is equal to _value_.
+當 _anotherfield_ 欄位等於 _value_ 的時候，該驗證的欄位會從 `validate` 和 `validated` 方法回傳的請求資料中排除。
 
 <a name="rule-exclude-unless"></a>
 #### exclude_unless:_anotherfield_,_value_
 
-The field under validation will be excluded from the request data returned by the `validate` and `validated` methods unless _anotherfield_'s field is equal to _value_.
+當 _anotherfield_ 欄位不等於 _value_ 的時候，該驗證的欄位會從 `validate` 和 `validated` 方法回傳的請求資料中排除。
 
 <a name="rule-exists"></a>
 #### exists:_table_,_column_
 
-The field under validation must exist on a given database table.
+驗證欄位值必須存在一個指定的資料表中。
 
-#### Basic Usage Of Exists Rule
+#### Exists 規則的基本用法
 
     'state' => 'exists:states'
 
-If the `column` option is not specified, the field name will be used.
+如果沒有指定 `column` 選項，會採用欄位名稱。
 
-#### Specifying A Custom Column Name
+#### 指定欄位名稱
 
     'state' => 'exists:states,abbreviation'
 
-Occasionally, you may need to specify a specific database connection to be used for the `exists` query. You can accomplish this by prepending the connection name to the table name using "dot" syntax:
+有時候，你可能會指定 `exists` 查詢使用特定的資料庫連線。可以用「點」語法在資料表名稱前加上連線名稱來達成：
 
     'email' => 'exists:connection.staff,email'
 
-Instead of specifying the table name directly, you may specify the Eloquent model which should be used to determine the table name:
+可以指定 Eloquent 模型來確認資料表名稱，而不是直接指定資料表名稱：
 
     'user_id' => 'exists:App\User,id'
 
-If you would like to customize the query executed by the validation rule, you may use the `Rule` class to fluently define the rule. In this example, we'll also specify the validation rules as an array instead of using the `|` character to delimit them:
+如果想要客制驗證規則執行的查詢，可以用 `Rule` 類別來流暢地定義規則。在這個範例中，我們也會以陣列來表示驗證規則，而不是用 `|` 字元來分割：
 
     use Illuminate\Validation\Rule;
 
@@ -866,32 +866,32 @@ If you would like to customize the query executed by the validation rule, you ma
 <a name="rule-file"></a>
 #### file
 
-The field under validation must be a successfully uploaded file.
+驗證欄位必須是一個成功上傳的檔案。
 
 <a name="rule-filled"></a>
 #### filled
 
-The field under validation must not be empty when it is present.
+當驗證欄位存在時，不可以為空值。
 
 <a name="rule-gt"></a>
 #### gt:_field_
 
-The field under validation must be greater than the given _field_. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the [`size`](#rule-size) rule.
+驗證欄位必須大於給定的 _field_。驗證與被驗證的值必須是相同的型別。使用與 [`size`](#rule-size) 相同方式來驗證字串、數值、陣列和檔案。
 
 <a name="rule-gte"></a>
 #### gte:_field_
 
-The field under validation must be greater than or equal to the given _field_. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the [`size`](#rule-size) rule.
+驗證欄位必須大於等於給定的 _field_。驗證與被驗證的值必須是相同的型別。使用與 [`size`](#rule-size) 相同方式來驗證字串、數值、陣列和檔案。
 
 <a name="rule-image"></a>
 #### image
 
-The file under validation must be an image (jpeg, png, bmp, gif, svg, or webp)
+驗證欄位檔案必須為圖片格式（ jpeg、png、bmp、gif、或 svg ）。
 
 <a name="rule-in"></a>
 #### in:_foo_,_bar_,...
 
-The field under validation must be included in the given list of values. Since this rule often requires you to `implode` an array, the `Rule::in` method may be used to fluently construct the rule:
+驗證欄位必須包含在給定的列表中。由於這個規則經常需要你 `implode` 一個陣列，`Rule::in` 方法可以用來流暢地建構規則：
 
     use Illuminate\Validation\Rule;
 
@@ -905,79 +905,79 @@ The field under validation must be included in the given list of values. Since t
 <a name="rule-in-array"></a>
 #### in_array:_anotherfield_.*
 
-The field under validation must exist in _anotherfield_'s values.
+驗證欄位的值必須在 _anotherfield_ 陣列中存在。
 
 <a name="rule-integer"></a>
 #### integer
 
-The field under validation must be an integer.
+驗證欄位必須是一個整數。
 
-> {note} This validation rule does not verify that the input is of the "integer" variable type, only that the input is a string or numeric value that contains an integer.
+> {note} 這個驗證規則不會驗證是否是「整數」型別，只驗證輸入的整數或字串資料是否包含數值。
 
 <a name="rule-ip"></a>
 #### ip
 
-The field under validation must be an IP address.
+驗證欄位必須符合一個 IP 位址的格式。
 
 #### ipv4
 
-The field under validation must be an IPv4 address.
+驗證欄位必須符合一個 IPv4 位址的格式。
 
 #### ipv6
 
-The field under validation must be an IPv6 address.
+驗證欄位必須符合一個 IPv6 位址的格式。
 
 <a name="rule-json"></a>
 #### json
 
-The field under validation must be a valid JSON string.
+驗證欄位必須是一個有效的 JSON 字串。
 
 <a name="rule-lt"></a>
 #### lt:_field_
 
-The field under validation must be less than the given _field_. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the [`size`](#rule-size) rule.
+驗證欄位必須小於給定的 _field_。驗證與被驗證的值必須是相同的型別。使用與 [`size`](#rule-size) 相同方式來驗證字串、數值、陣列和檔案。
 
 <a name="rule-lte"></a>
 #### lte:_field_
 
-The field under validation must be less than or equal to the given _field_. The two fields must be of the same type. Strings, numerics, arrays, and files are evaluated using the same conventions as the [`size`](#rule-size) rule.
+驗證欄位必須小於等於給定的 _field_。驗證與被驗證的值必須是相同的型別。字串、數值和檔案大小的計算方式和 [`size`](#rule-size) 規則相同。
 
 <a name="rule-max"></a>
 #### max:_value_
 
-The field under validation must be less than or equal to a maximum _value_. Strings, numerics, arrays, and files are evaluated in the same fashion as the [`size`](#rule-size) rule.
+驗證欄位值的大小是否小於或等於 _value_。字串、數值和檔案大小的計算方式和 [`size`](#rule-size) 規則相同。
 
 <a name="rule-mimetypes"></a>
 #### mimetypes:_text/plain_,...
 
-The file under validation must match one of the given MIME types:
+驗證檔案必須符合給定的 MIME 類型之一。
 
     'video' => 'mimetypes:video/avi,video/mpeg,video/quicktime'
 
-To determine the MIME type of the uploaded file, the file's contents will be read and the framework will attempt to guess the MIME type, which may be different from the client provided MIME type.
+為了判斷上傳檔案的 MIME 類型，檔案的內容會被讀取，框架會嘗試猜測 MIME 類型，這可能與客戶端提供的 MIME 類型不同。
 
 <a name="rule-mimes"></a>
 #### mimes:_foo_,_bar_,...
 
-The file under validation must have a MIME type corresponding to one of the listed extensions.
+驗證檔案的 MIME 類型必須符合清單裡的副檔名之一。
 
-#### Basic Usage Of MIME Rule
+#### MIME 規則基本用法
 
     'photo' => 'mimes:jpeg,bmp,png'
 
-Even though you only need to specify the extensions, this rule actually validates against the MIME type of the file by reading the file's contents and guessing its MIME type.
+即便只需要指定副檔名，但此規則實際上透過讀取檔案內容，並猜測 MIME 類型來驗證。
 
-A full listing of MIME types and their corresponding extensions may be found at the following location: [https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types](https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types)
+完整的 MIME 類型及對應的副檔名清單可以在下方連結找到：[https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types](https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types)
 
 <a name="rule-min"></a>
 #### min:_value_
 
-The field under validation must have a minimum _value_. Strings, numerics, arrays, and files are evaluated in the same fashion as the [`size`](#rule-size) rule.
+驗證欄位值的大小是否小於或等於 _value_。字串、數值或是檔案大小的計算方式和 [`size`](#rule-size) 規則相同。
 
 <a name="rule-not-in"></a>
 #### not_in:_foo_,_bar_,...
 
-The field under validation must not be included in the given list of values. The `Rule::notIn` method may be used to fluently construct the rule:
+驗證欄位值不在給定的清單裡。`Rule::notIn` 方法可以用來流暢地建構規則：
 
     use Illuminate\Validation\Rule;
 
@@ -991,63 +991,63 @@ The field under validation must not be included in the given list of values. The
 <a name="rule-not-regex"></a>
 #### not_regex:_pattern_
 
-The field under validation must not match the given regular expression.
+驗證欄位值不能符合給定的正規表示式。
 
-Internally, this rule uses the PHP `preg_match` function. The pattern specified should obey the same formatting required by `preg_match` and thus also include valid delimiters. For example: `'email' => 'not_regex:/^.+$/i'`.
+其中，這個規則有用到 PHP 的 `preg_match` 函式。選用的模式需要與 `preg_match` 使用相同的格式，因此還要有分隔符號。例如：`'email' => 'not_regex:/^.+$/i'`。
 
-**Note:** When using the `regex` / `not_regex` patterns, it may be necessary to specify rules in an array instead of using pipe delimiters, especially if the regular expression contains a pipe character.
+**注意:**在使用 `regex` 規則時，你可能得使用陣列而不是 `|` 分隔符號來指定規則，特別是當正規表示式含有 `|` 字元時。
 
 <a name="rule-nullable"></a>
 #### nullable
 
-The field under validation may be `null`. This is particularly useful when validating primitive such as strings and integers that can contain `null` values.
+驗證欄位值可以為 `null`。在驗證可能含有 `null` 值的基本型別（如字串或整數）時特別有用。
 
 <a name="rule-numeric"></a>
 #### numeric
 
-The field under validation must be numeric.
+驗證欄位值是否為數值。
 
 <a name="rule-password"></a>
 #### password
 
-The field under validation must match the authenticated user's password. You may specify an authentication guard using the rule's first parameter:
+驗證欄位必須與認證過的使用者密碼相符合，你可以使用該規則的第一個參數來指定身份認證的守衛：
 
     'password' => 'password:api'
 
 <a name="rule-present"></a>
 #### present
 
-The field under validation must be present in the input data but can be empty.
+驗證欄位一定要有值，但可為空值。
 
 <a name="rule-regex"></a>
 #### regex:_pattern_
 
-The field under validation must match the given regular expression.
+驗證欄位值符合給定的正規表示式。
 
-Internally, this rule uses the PHP `preg_match` function. The pattern specified should obey the same formatting required by `preg_match` and thus also include valid delimiters. For example: `'email' => 'regex:/^.+@.+$/i'`.
+其中，這個規則有用到 PHP 的 `preg_match` 函式。選用的模式需要與 `preg_match` 使用相同的格式，因此還要有分隔符號。例如：`'email' => 'not_regex:/^.+$/i'`。
 
-**Note:** When using the `regex` / `not_regex` patterns, it may be necessary to specify rules in an array instead of using pipe delimiters, especially if the regular expression contains a pipe character.
+**注意:**在使用 `regex` 規則時，你可能得使用陣列而不是 `|` 分隔符號來指定規則，特別是當正規表示式含有 `|` 字元時。
 
 <a name="rule-required"></a>
 #### required
 
-The field under validation must be present in the input data and not empty. A field is considered "empty" if one of the following conditions are true:
+驗證欄位必須有值且不為空值。欄位符合下方任一條件時為「空值」：
 
 <div class="content-list" markdown="1">
 
-- The value is `null`.
-- The value is an empty string.
-- The value is an empty array or empty `Countable` object.
-- The value is an uploaded file with no path.
+- 該值為 `null`.
+- 該值為空字串。
+- 該值為空陣列或空的 `Countable` 物件。
+- 該值為沒有路徑的上傳檔案。
 
 </div>
 
 <a name="rule-required-if"></a>
 #### required_if:_anotherfield_,_value_,...
 
-The field under validation must be present and not empty if the _anotherfield_ field is equal to any _value_.
+如果指定的_其它欄位（ anotherfield ）_等於任何一個 _value_ 時，此欄位必須有值且不為空值。
 
-If you would like to construct a more complex condition for the `required_if` rule, you may use the `Rule::requiredIf` method. This methods accepts a boolean or a Closure. When passed a Closure, the Closure should return `true` or `false` to indicate if the field under validation is required:
+如果你想要為 `required_if` 規則建構更複雜的條件，你可以使用 `Rule::requiredIf`。這個方法接受布林值或閉包。若傳入的是閉包，閉包會依據回傳 的是 `true` 或 `false` 來判斷是否需要驗證欄位：
 
     use Illuminate\Validation\Rule;
 
@@ -1064,91 +1064,91 @@ If you would like to construct a more complex condition for the `required_if` ru
 <a name="rule-required-unless"></a>
 #### required_unless:_anotherfield_,_value_,...
 
-The field under validation must be present and not empty unless the _anotherfield_ field is equal to any _value_.
+此欄位必須有值且不為空值，除非指定的_其它欄位（ anotherfield ）_等於任何一個 _value_。
 
 <a name="rule-required-with"></a>
 #### required_with:_foo_,_bar_,...
 
-The field under validation must be present and not empty _only if_ any of the other specified fields are present.
+如果指定的_任一_欄位有值，則此欄位必須有值且不為空值。
 
 <a name="rule-required-with-all"></a>
 #### required_with_all:_foo_,_bar_,...
 
-The field under validation must be present and not empty _only if_ all of the other specified fields are present.
+如果指定的_所有_欄位都有值，則此欄位必須有值且不為空值。
 
 <a name="rule-required-without"></a>
 #### required_without:_foo_,_bar_,...
 
-The field under validation must be present and not empty _only when_ any of the other specified fields are not present.
+如果_任一_指定的欄位不存在時，則此欄位必須有值且不為空值。
 
 <a name="rule-required-without-all"></a>
 #### required_without_all:_foo_,_bar_,...
 
-The field under validation must be present and not empty _only when_ all of the other specified fields are not present.
+如果_所有_指定的欄位不存在時，則此欄位必須有值且不為空值。
 
 <a name="rule-same"></a>
 #### same:_field_
 
-The given _field_ must match the field under validation.
+驗證欄位值和指定的_欄位（ field ）_值相同。
 
 <a name="rule-size"></a>
 #### size:_value_
 
-The field under validation must have a size matching the given _value_. For string data, _value_ corresponds to the number of characters. For numeric data, _value_ corresponds to a given integer value (the attribute must also have the `numeric` or `integer` rule). For an array, _size_ corresponds to the `count` of the array. For files, _size_ corresponds to the file size in kilobytes. Let's look at some examples:
+驗證欄位值的大小需符合給定 _value_ 值。對於字串來說，_value_ 為字元數。對於數字來說，_value_ 為指定的整數值（該屬性最好有 `numeric` 或 `integer` 規則）。對陣列來說，_size_ 對應陣列的 `count`。對檔案來說，_size_ 對應到的是檔案大小（單位 kb ）。讓我們看一些範例：
 
-    // Validate that a string is exactly 12 characters long...
+    // 驗證字串的長度為 12 字元...
     'title' => 'size:12';
 
-    // Validate that a provided integer equals 10...
+    // 驗證數值等於 10...
     'seats' => 'integer|size:10';
 
-    // Validate that an array has exactly 5 elements...
+    // 驗證陣列有五個元素...
     'tags' => 'array|size:5';
 
-    // Validate that an uploaded file is exactly 512 kilobytes...
+    // 驗證上傳的檔案是 512 kb...
     'image' => 'file|size:512';
 
 <a name="rule-starts-with"></a>
 #### starts_with:_foo_,_bar_,...
 
-The field under validation must start with one of the given values.
+驗證欄位的開頭有其中一個給定的值。
 
 <a name="rule-string"></a>
 #### string
 
-The field under validation must be a string. If you would like to allow the field to also be `null`, you should assign the `nullable` rule to the field.
+驗證欄位值的型別是否為字串。如果想允許欄位可為 `null`，可以指定 `nullable` 規則給欄位。
 
 <a name="rule-timezone"></a>
 #### timezone
 
-The field under validation must be a valid timezone identifier according to the `timezone_identifiers_list` PHP function.
+驗證欄位值是否為有效的時區，會根據 PHP 的 `timezone_identifiers_list` 函式來判斷。
 
 <a name="rule-unique"></a>
 #### unique:_table_,_column_,_except_,_idColumn_
 
-The field under validation must not exist within the given database table.
+在給定的資料表，驗證欄位中必須是唯一的。如果沒有指定 `column`，將會使用欄位本身的名稱。
 
-**Specifying A Custom Table / Column Name:**
+**指定自訂的資料表與欄位名稱：**
 
-Instead of specifying the table name directly, you may specify the Eloquent model which should be used to determine the table name:
+你可以指定 Eloquent 模型來確認資料表名稱，而不是直接指定資料表名稱：
 
     'email' => 'unique:App\User,email_address'
 
-The `column` option may be used to specify the field's corresponding database column. If the `column` option is not specified, the field name will be used.
+`column` 選項可被用於指定對應的資料庫欄位。如果未指定 `column` 選項，則會使用驗證的欄位名稱。
 
     'email' => 'unique:users,email_address'
 
-**Custom Database Connection**
+**自訂資料庫連線**
 
-Occasionally, you may need to set a custom connection for database queries made by the Validator. As seen above, setting `unique:users` as a validation rule will use the default database connection to query the database. To override this, specify the connection and the table name using "dot" syntax:
+有時候你可能需要驗證器透過自訂的連線來對資料庫進行查詢。如上面所示，設定 `unique:users` 作為驗證規則，會透過預設資料庫連線來做資料庫查詢。如果要覆寫，用「.」語法來指定連線跟資料表名稱：
 
     'email' => 'unique:connection.users,email_address'
 
-**Forcing A Unique Rule To Ignore A Given ID:**
+**強迫 Unique 規則忽略特定 ID：**
 
-Sometimes, you may wish to ignore a given ID during the unique check. For example, consider an "update profile" screen that includes the user's name, e-mail address, and location. You will probably want to verify that the e-mail address is unique. However, if the user only changes the name field and not the e-mail field, you do not want a validation error to be thrown because the user is already the owner of the e-mail address.
+有時候會希望在驗證欄位的時候忽略給定的 ID。例如，在「更新個人資料」時包含使用者名稱、信箱和所在區域。當然，你會想要驗證 e-mail 是否為唯一的。但如果使用者只更改名稱欄位而沒有異動 e-mail 欄位，不應該拋出驗證錯誤，因為使用者已經是這個 e-mail 的擁有者。
 
-To instruct the validator to ignore the user's ID, we'll use the `Rule` class to fluently define the rule. In this example, we'll also specify the validation rules as an array instead of using the `|` character to delimit the rules:
+我們會用 `Rule` 類別來流暢地定義規則，來指示驗證器忽略使用者 ID。在這個範例中，我們同時也使用陣列而不是 `|` 字元來分隔規則：
 
     use Illuminate\Validation\Rule;
 
@@ -1159,23 +1159,23 @@ To instruct the validator to ignore the user's ID, we'll use the `Rule` class to
         ],
     ]);
 
-> {note} You should never pass any user controlled request input into the `ignore` method. Instead, you should only pass a system generated unique ID such as an auto-incrementing ID or UUID from an Eloquent model instance. Otherwise, your application will be vulnerable to an SQL injection attack.
+> {note} 始終不該把使用者控制的請求傳入 `ignore` 方法。相對的，你應該只傳入系統產生的唯一 ID，像是從 Eloquent 模型實例自動遞增的 ID 或 UUID。否則你的應用程式將容易遭受 SQL 注入攻擊。
 
-Instead of passing the model key's value to the `ignore` method, you may pass the entire model instance. Laravel will automatically extract the key from the model:
+可以傳整個模型實例到 `ignore` 方法，而不是傳入模型的鍵值。Laravel 會自動從模型中取得這個鍵：
 
     Rule::unique('users')->ignore($user)
 
-If your table uses a primary key column name other than `id`, you may specify the name of the column when calling the `ignore` method:
+如果你的資料表的主鍵是使用 `id` 以為的欄位名稱，你可以在呼叫 `ignore` 方法時指定該欄位名稱：
 
     Rule::unique('users')->ignore($user->id, 'user_id')
 
-By default, the `unique` rule will check the uniqueness of the column matching the name of the attribute being validated. However, you may pass a different column name as the second argument to the `unique` method:
+預設的 `unique` 規則會檢查被驗證的屬性是否達到該欄位的唯一值。然而，你可以傳入不同的欄位名稱到 `unique` 方法的第二個參數：
 
     Rule::unique('users', 'email_address')->ignore($user->id),
 
-**Adding Additional Where Clauses:**
+**加入其他的 Where 閉包:**
 
-You may also specify additional query constraints by customizing the query using the `where` method. For example, let's add a constraint that verifies the `account_id` is `1`:
+你也可以使用 `where` 方法來自訂查詢指定的查詢條件。像是，加入一個驗證 `account_id` 是 `1` 的條件：
 
     'email' => Rule::unique('users')->where(function ($query) {
         return $query->where('account_id', 1);
@@ -1184,19 +1184,19 @@ You may also specify additional query constraints by customizing the query using
 <a name="rule-url"></a>
 #### url
 
-The field under validation must be a valid URL.
+驗證欄位值必須符合 URL 格式。
 
 <a name="rule-uuid"></a>
 #### uuid
 
-The field under validation must be a valid RFC 4122 (version 1, 3, 4, or 5) universally unique identifier (UUID).
+驗證欄位必須是有效的 RFC 4122（版本 1、3、4 或 5）的唯一識別（UUID）。
 
 <a name="conditionally-adding-rules"></a>
-## Conditionally Adding Rules
+## 有條件的加入規則
 
-#### Skipping Validation When Fields Have Certain Values
+#### 當欄位有特定的值時，就略過驗證
 
-You may occasionally wish to not validate a given field if another field has a given value. You may accomplish this using the `exclude_if` validation rule. In this example, the `appointment_date` and `doctor_name` fields will not be validated if the `has_appointment` field has a value of `false`:
+有時你會想要在另一個欄位有給定的值時不去驗證當前的欄位。可以使用 `exclude_if` 驗證規則來達到這個目的。在這個範例中，`appointment_date` 和 `doctor_name` 欄位會在 `has_appointment` 欄位的值為 `false` 時不做驗證：
 
     $v = Validator::make($data, [
         'has_appointment' => 'required|bool',
@@ -1204,7 +1204,7 @@ You may occasionally wish to not validate a given field if another field has a g
         'doctor_name' => 'exclude_if:has_appointment,false|required|string',
     ]);
 
-Alternatively, you may use the `exclude_unless` rule to not validate a given field unless another field has a given value:
+相對的，你可以使用 `exclude_unless` 規則來不驗證給定的欄位，除非另一個欄位有給定的值：
 
     $v = Validator::make($data, [
         'has_appointment' => 'required|bool',
@@ -1212,76 +1212,76 @@ Alternatively, you may use the `exclude_unless` rule to not validate a given fie
         'doctor_name' => 'exclude_unless:has_appointment,true|required|string',
     ]);
 
-#### Validating When Present
+#### 依條件增加規則
 
-In some situations, you may wish to run validation checks against a field **only** if that field is present in the input array. To quickly accomplish this, add the `sometimes` rule to your rule list:
+在某些情況下，你可能**只**想在輸入資料中有此欄位時才進行驗證。只要增加 `sometimes` 規則到進規則清單中，就可以快速達成：
 
     $v = Validator::make($data, [
         'email' => 'sometimes|required|email',
     ]);
 
-In the example above, the `email` field will only be validated if it is present in the `$data` array.
+在上面的範例中，`email` 欄位的驗證，只會在 `$data` 陣列有此欄位才會進行。
 
-> {tip} If you are attempting to validate a field that should always be present but may be empty, check out [this note on optional fields](#a-note-on-optional-fields)
+> 如果你在嘗試驗證一定會存在但可能為空值的欄位，請查看[關於可選欄位的說明](#a-note-on-optional-fields)
 
-#### Complex Conditional Validation
+#### 複雜的條件驗證
 
-Sometimes you may wish to add validation rules based on more complex conditional logic. For example, you may wish to require a given field only if another field has a greater value than 100. Or, you may need two fields to have a given value only when another field is present. Adding these validation rules doesn't have to be a pain. First, create a `Validator` instance with your _static rules_ that never change:
+有時候你可能希望以更複雜的條件邏輯來增加驗證規則。例如，你可以希望某個欄位，在另一個欄位的值超過 100 時才為必填。或者當某個指定欄位有值時，另外兩個欄位要符合特定值。增加這樣的驗證條件並不痛苦。首先，利用你熟悉的 _static rules_ 建立一個 `Validator` 實例：
 
     $v = Validator::make($data, [
         'email' => 'required|email',
         'games' => 'required|numeric',
     ]);
 
-Let's assume our web application is for game collectors. If a game collector registers with our application and they own more than 100 games, we want them to explain why they own so many games. For example, perhaps they run a game resale shop, or maybe they just enjoy collecting. To conditionally add this requirement, we can use the `sometimes` method on the `Validator` instance.
+假設我們的網頁應用程式是專為遊戲收藏家所設計。如果遊戲收藏家收藏超過一百款遊戲，我們希望他們說明為什麼他們擁有這麼多遊戲。像是，可能他們經營一家二手遊戲商店，或是他們可能只是愛收集。為了在特定條件下加入此驗證需求，我們可以在 `Validator` 實例使用 `sometimes` 方法。
 
     $v->sometimes('reason', 'required|max:500', function ($input) {
         return $input->games >= 100;
     });
 
-The first argument passed to the `sometimes` method is the name of the field we are conditionally validating. The second argument is the rules we want to add. If the `Closure` passed as the third argument returns `true`, the rules will be added. This method makes it a breeze to build complex conditional validations. You may even add conditional validations for several fields at once:
+傳入 `sometimes` 方法的第一個參數，是我們要依條件驗證的欄位名稱。第二個參數是我們想加入的驗證規則。如果第三個參數傳入的`閉包`回傳 `true`，此規則就會被加入。這個方法可以輕鬆的建立複雜的條件驗證。甚至可以一次對多個欄位增加條件式驗證：
 
     $v->sometimes(['reason', 'cost'], 'required', function ($input) {
         return $input->games >= 100;
     });
 
-> {tip} The `$input` parameter passed to your `Closure` will be an instance of `Illuminate\Support\Fluent` and may be used to access your input and files.
+> {tip} 傳入`閉包`的 `$input` 參數是 `Illuminate\Support\Fluent` 實例，可以用來取得輸入的資料和檔案。
 
 <a name="validating-arrays"></a>
-## Validating Arrays
+## 驗證陣列
 
-Validating array based form input fields doesn't have to be a pain. You may use "dot notation" to validate attributes within an array. For example, if the incoming HTTP request contains a `photos[profile]` field, you may validate it like so:
+驗證陣列類型的表單輸入欄位並不難。可以使用「點符號」來驗證陣列中的屬性。比如說，如果傳入的 HTTP 請求包含 `photos[profile]` 欄位，可以這樣驗證：
 
     $validator = Validator::make($request->all(), [
         'photos.profile' => 'required|image',
     ]);
 
-You may also validate each element of an array. For example, to validate that each e-mail in a given array input field is unique, you may do the following:
+也可以驗證陣列中的每個元素。比如這樣做可以驗證給定的陣列輸入欄位中的 e-mail 都是唯一的：
 
     $validator = Validator::make($request->all(), [
         'person.*.email' => 'email|unique:users',
         'person.*.first_name' => 'required_with:person.*.last_name',
     ]);
 
-Likewise, you may use the `*` character when specifying your validation messages in your language files, making it a breeze to use a single validation message for array based fields:
+同樣也可以在語系檔中用 `*` 字元來來定義驗證訊息，輕鬆的讓陣列欄位利用單個驗證訊息：
 
     'custom' => [
         'person.*.email' => [
-            'unique' => 'Each person must have a unique e-mail address',
+            'unique' => '每個人都要有唯一的 e-mail 位址',
         ]
     ],
 
 <a name="custom-validation-rules"></a>
-## Custom Validation Rules
+## 自訂驗證規則
 
 <a name="using-rule-objects"></a>
-### Using Rule Objects
+### 使用規則物件
 
-Laravel provides a variety of helpful validation rules; however, you may wish to specify some of your own. One method of registering custom validation rules is using rule objects. To generate a new rule object, you may use the `make:rule` Artisan command. Let's use this command to generate a rule that verifies a string is uppercase. Laravel will place the new rule in the `app/Rules` directory:
+Laravel 提供多種有用的驗證規則；但你可能想要定義一些自己的規則。一種註冊自訂驗證規則的方式是使用規則物件。使用 `make:rule` Artisan 指令來產生新的規則物件。讓我們用這個指令來產生一個驗證字串是否為大寫的規則。Laravel 會把新的規則放在 `app/Rules` 目錄下：
 
     php artisan make:rule Uppercase
 
-Once the rule has been created, we are ready to define its behavior. A rule object contains two methods: `passes` and `message`. The `passes` method receives the attribute value and name, and should return `true` or `false` depending on whether the attribute value is valid or not. The `message` method should return the validation error message that should be used when validation fails:
+規則被建立後，我們就可以來定義它的行為。一個規則物件包含兩個方法：`passes` 和 `message`。`passes` 方法接收屬性值和名稱，並根據屬性值是否合法來回傳 `true` 或 `false`。`message` 方法應該回傳驗證失敗時使用的驗證錯誤訊息。
 
     <?php
 
@@ -1292,7 +1292,7 @@ Once the rule has been created, we are ready to define its behavior. A rule obje
     class Uppercase implements Rule
     {
         /**
-         * Determine if the validation rule passes.
+         * 判斷驗證規則是否通過。
          *
          * @param  string  $attribute
          * @param  mixed  $value
@@ -1304,7 +1304,7 @@ Once the rule has been created, we are ready to define its behavior. A rule obje
         }
 
         /**
-         * Get the validation error message.
+         * 取得驗證錯誤訊息。
          *
          * @return string
          */
@@ -1314,10 +1314,10 @@ Once the rule has been created, we are ready to define its behavior. A rule obje
         }
     }
 
-You may call the `trans` helper from your `message` method if you would like to return an error message from your translation files:
+如果想要從翻譯檔中取回錯誤訊息，也可以在 `message` 方法中呼叫 `trans` 輔助函式。
 
     /**
-     * Get the validation error message.
+     * 取得驗證錯誤訊息。
      *
      * @return string
      */
@@ -1326,7 +1326,7 @@ You may call the `trans` helper from your `message` method if you would like to 
         return trans('validation.uppercase');
     }
 
-Once the rule has been defined, you may attach it to a validator by passing an instance of the rule object with your other validation rules:
+定義好規則後，可以藉由傳遞規則物件實例來附加到其他的驗證規則中：
 
     use App\Rules\Uppercase;
 
@@ -1335,9 +1335,9 @@ Once the rule has been defined, you may attach it to a validator by passing an i
     ]);
 
 <a name="using-closures"></a>
-### Using Closures
+### 使用閉包
 
-If you only need the functionality of a custom rule once throughout your application, you may use a Closure instead of a rule object. The Closure receives the attribute's name, the attribute's value, and a `$fail` callback that should be called if validation fails:
+如果整個應用程式只需要使用一次的自訂規則功能，你可以使用閉包來取代規則物件。閉包會接收屬性名稱與值，還有驗證失敗後呼叫的回呼：
 
     $validator = Validator::make($request->all(), [
         'title' => [
@@ -1352,9 +1352,9 @@ If you only need the functionality of a custom rule once throughout your applica
     ]);
 
 <a name="using-extensions"></a>
-### Using Extensions
+### 使用擴充功能
 
-Another method of registering custom validation rules is using the `extend` method on the `Validator` [facade](/docs/{{version}}/facades). Let's use this method within a [service provider](/docs/{{version}}/providers) to register a custom validation rule:
+另一種註冊自訂驗證規則的方法是使用 `Validator` [facade](/docs/{{version}}/facades) 的 `extend` 方法。讓我們在[服務提供者](/docs/{{version}}/providers)中使用這個方法來自訂註冊的驗證規則：
 
     <?php
 
@@ -1366,7 +1366,7 @@ Another method of registering custom validation rules is using the `extend` meth
     class AppServiceProvider extends ServiceProvider
     {
         /**
-         * Register any application services.
+         * 註冊服務提供者。
          *
          * @return void
          */
@@ -1376,7 +1376,7 @@ Another method of registering custom validation rules is using the `extend` meth
         }
 
         /**
-         * Bootstrap any application services.
+         * 啟動所有應用程式服務。
          *
          * @return void
          */
@@ -1388,26 +1388,26 @@ Another method of registering custom validation rules is using the `extend` meth
         }
     }
 
-The custom validator Closure receives four arguments: the name of the `$attribute` being validated, the `$value` of the attribute, an array of `$parameters` passed to the rule, and the `Validator` instance.
+自訂的驗證閉包接收四個參數：要被驗證的屬性名稱 `$attribute`，屬性的值 `$value`，傳入驗證規則的參數陣列 `$parameters`，及 `Validator `實例。
 
-You may also pass a class and method to the `extend` method instead of a Closure:
+除了使用閉包，你也可以傳入類別和方法到 `extend` 方法中：
 
     Validator::extend('foo', 'FooValidator@validate');
 
-#### Defining The Error Message
+#### 定義錯誤訊息
 
-You will also need to define an error message for your custom rule. You can do so either using an inline custom message array or by adding an entry in the validation language file. This message should be placed in the first level of the array, not within the `custom` array, which is only for attribute-specific error messages:
+在自訂規則中也需要定義錯誤訊息。可以使用行內的自訂訊息陣列或在驗證語系檔中加入加入一個條目。這個訊息應該被放在陣列的第一層，而不是放在對應特定屬性錯誤訊息的 `custom` 陣列：
 
-    "foo" => "Your input was invalid!",
+    "foo" => "你的輸入無效！",
 
-    "accepted" => "The :attribute must be accepted.",
+    "accepted" => ":attribute 必須被接受。",
 
-    // The rest of the validation error messages...
+    // 其餘的驗證錯誤訊息...
 
-When creating a custom validation rule, you may sometimes need to define custom placeholder replacements for error messages. You may do so by creating a custom Validator as described above then making a call to the `replacer` method on the `Validator` facade. You may do this within the `boot` method of a [service provider](/docs/{{version}}/providers):
+在建立自訂的驗證規則時，你可能需要幫錯誤訊息定義自訂的佔位符。用如上所述的方式建立自訂的驗證器後，呼叫 `Validator` facade 的 `replacer` 方法。可以在[服務提供者](/docs/{{version}}/providers)中的 `boot` 方法來做這些事：
 
     /**
-     * Bootstrap any application services.
+     * 啟動所有應用程式服務。
      *
      * @return void
      */
@@ -1421,9 +1421,9 @@ When creating a custom validation rule, you may sometimes need to define custom 
     }
 
 <a name="implicit-extensions"></a>
-### Implicit Extensions
+### 隱式擴充功能
 
-By default, when an attribute being validated is not present or contains an empty string, normal validation rules, including custom extensions, are not run. For example, the [`unique`](#rule-unique) rule will not be run against an empty string:
+預設情況下，當被驗證的屬性不存在或是空字串時，則不會去執行一般和自訂擴充的驗證規則。例如，[`unique`](#rule-unique) 規則不會在空字串上執行：
 
     $rules = ['name' => 'unique:users,name'];
 
@@ -1431,14 +1431,14 @@ By default, when an attribute being validated is not present or contains an empt
 
     Validator::make($input, $rules)->passes(); // true
 
-For a rule to run even when an attribute is empty, the rule must imply that the attribute is required. To create such an "implicit" extension, use the `Validator::extendImplicit()` method:
+若要當屬性為空時依然執行該規則，那麼該規則必須暗示屬性為必填。要建立這樣的一個「隱式」擴充功能，使用 `Validator::extendImplicit()` 方法：
 
     Validator::extendImplicit('foo', function ($attribute, $value, $parameters, $validator) {
         return $value == 'foo';
     });
 
-> {note} An "implicit" extension only _implies_ that the attribute is required. Whether it actually invalidates a missing or empty attribute is up to you.
+> {note} 「隱式」擴充功能只能_確保_該屬性為必填。由你決定不存在的屬性或空值是否無效。
 
-#### Implicit Rule Objects
+#### 隱式規則物件
 
-If you would like a rule object to run when an attribute is empty, you should implement the `Illuminate\Contracts\Validation\ImplicitRule` interface. This interface serves as a "marker interface" for the validator; therefore, it does not contain any methods you need to implement.
+如果你想要在屬性為空值時執行規則物件，應去實作 `Illuminate\Contracts\Validation\ImplicitRule` 介面。這個介面是驗證器的「標記介面」。所以它並不會需要你實作任何方法。


### PR DESCRIPTION
Translate validation.md (7.x)

- 應該超過一半的翻譯是從 `5.5` 搬來的。
- `Implicit` 在過去是直翻為`隱式`，但這個翻譯真的不易理解，所以有點想要翻成`被動`。在句中為動詞時，被翻成`暗示`，可考慮改為`被`。像是「規則必須暗示屬性為必填」這句，改成「規則的屬性必須被要求是必填」。（尚未實作）